### PR TITLE
Fix lbtc unit

### DIFF
--- a/src/features/operator/Market/MarketWithdraw/index.tsx
+++ b/src/features/operator/Market/MarketWithdraw/index.tsx
@@ -11,7 +11,7 @@ import { CurrencyIcon } from '../../../../common/CurrencyIcon';
 import { SelectMarket } from '../../../../common/SelectMarket';
 import type { Asset } from '../../../../domain/asset';
 import { HOME_ROUTE } from '../../../../routes/constants';
-import { formatFiatToSats, formatSatsToUnit } from '../../../../utils';
+import { formatFiatToSats, formatLbtcUnitToSats, formatSatsToUnit, isLbtc } from '../../../../utils';
 import { useGetMarketBalanceQuery, useListMarketsQuery, useWithdrawMarketMutation } from '../../operator.api';
 
 const { Title } = Typography;
@@ -59,9 +59,14 @@ export const MarketWithdraw = (): JSX.Element => {
           baseAsset: selectedAssetMarket?.[0].asset_id,
           quoteAsset: selectedAssetMarket?.[1].asset_id,
         },
+        // Expect lbtc amount to be in favorite user unit
         balance: {
-          baseAmount: values.balanceBaseAmount,
-          quoteAmount: Number(formatFiatToSats(values.balanceQuoteAmount)),
+          baseAmount: isLbtc(selectedAssetMarket?.[0].ticker)
+            ? Number(formatLbtcUnitToSats(values.balanceBaseAmount, lbtcUnit))
+            : Number(formatFiatToSats(values.balanceBaseAmount)),
+          quoteAmount: isLbtc(selectedAssetMarket?.[1].ticker)
+            ? Number(formatLbtcUnitToSats(values.balanceQuoteAmount, lbtcUnit))
+            : Number(formatFiatToSats(values.balanceQuoteAmount)),
         },
         address: values.address,
         millisatsPerByte: 100,
@@ -165,7 +170,7 @@ export const MarketWithdraw = (): JSX.Element => {
                         });
                       }
                     }}
-                  >{`${baseAmountFormatted} ${selectedMarket.baseAsset?.ticker}`}</Button>
+                  >{`${baseAmountFormatted} ${lbtcUnit}`}</Button>
                 </Col>
                 <Col className="dm-mono dm-mono__bold d-flex justify-end" span={12}>
                   0.00 USD

--- a/src/features/operator/TxsTable/DepositRows.tsx
+++ b/src/features/operator/TxsTable/DepositRows.tsx
@@ -7,7 +7,7 @@ import type { Deposit, MarketInfo } from '../../../api-spec/generated/js/operato
 import { ReactComponent as depositIcon } from '../../../assets/images/deposit.svg';
 import type { Asset } from '../../../domain/asset';
 import type { LbtcUnit } from '../../../utils';
-import { assetIdToTicker, timeAgo, formatSatsToUnit } from '../../../utils';
+import { assetIdToTicker, timeAgo, formatSatsToUnit, isLbtc } from '../../../utils';
 import { useGetTransactionByIdQuery } from '../../liquid.api';
 
 interface DepositRowsProps {
@@ -59,6 +59,8 @@ const DepositRow = ({
       ? formatSatsToUnit(Number(quoteAmount), lbtcUnit, marketInfo.market?.quoteAsset)
       : 'N/A';
   const time = timestampUnix || tx?.status.block_time;
+  const baseAssetTickerFormatted = isLbtc(baseAssetTicker) ? lbtcUnit : baseAssetTicker;
+  const quoteAssetTickerFormatted = isLbtc(quoteAssetTicker) ? lbtcUnit : quoteAssetTicker;
   return (
     <>
       <tr
@@ -69,11 +71,11 @@ const DepositRow = ({
       >
         <td>
           <Icon component={depositIcon} className="tx-icon" />
-          {`Deposit ${quoteAssetTicker}`}
+          {`Deposit ${quoteAssetTickerFormatted}`}
         </td>
         <td>{`$${quoteAmountFormatted}`}</td>
-        <td>{`${baseAmountFormatted} ${baseAssetTicker}`}</td>
-        <td>{`${quoteAmountFormatted} ${quoteAssetTicker}`}</td>
+        <td>{`${baseAmountFormatted} ${baseAssetTickerFormatted}`}</td>
+        <td>{`${quoteAmountFormatted} ${quoteAssetTickerFormatted}`}</td>
         <td data-time={time}>{timeAgo(time)}</td>
         <td>
           <RightOutlined />

--- a/src/features/operator/TxsTable/TradeRows.tsx
+++ b/src/features/operator/TxsTable/TradeRows.tsx
@@ -6,7 +6,7 @@ import type { TradeInfo } from '../../../api-spec/generated/js/operator_pb';
 import { CurrencyIcon } from '../../../common/CurrencyIcon';
 import type { Asset } from '../../../domain/asset';
 import type { LbtcUnit } from '../../../utils';
-import { assetIdToTicker, timeAgo, formatSatsToUnit } from '../../../utils';
+import { assetIdToTicker, timeAgo, formatSatsToUnit, isLbtc } from '../../../utils';
 
 export interface Trade {
   txUrl: TradeInfo.AsObject['txUrl'];
@@ -27,6 +27,8 @@ export const TradeRows = ({ trades, savedAssets, lbtcUnit }: TradeRowsProps): JS
       {trades?.map(({ swapInfo, txUrl, status, settleTimeUnix }) => {
         const baseAssetTicker = assetIdToTicker(swapInfo?.assetP || '', savedAssets);
         const quoteAssetTicker = assetIdToTicker(swapInfo?.assetR || '', savedAssets);
+        const baseAssetTickerFormatted = isLbtc(baseAssetTicker) ? lbtcUnit : baseAssetTicker;
+        const quoteAssetTickerFormatted = isLbtc(quoteAssetTicker) ? lbtcUnit : quoteAssetTicker;
         const baseAmount =
           swapInfo?.amountR === undefined
             ? 'N/A'
@@ -36,6 +38,7 @@ export const TradeRows = ({ trades, savedAssets, lbtcUnit }: TradeRowsProps): JS
             ? 'N/A'
             : formatSatsToUnit(swapInfo?.amountR, lbtcUnit, swapInfo?.assetR);
         const txId = txUrl.substring(txUrl.lastIndexOf('/') + 1, txUrl.indexOf('#'));
+
         return (
           <>
             <tr
@@ -49,11 +52,11 @@ export const TradeRows = ({ trades, savedAssets, lbtcUnit }: TradeRowsProps): JS
                   <CurrencyIcon className="base-icon" currency={baseAssetTicker || ''} size={16} />
                   <CurrencyIcon className="quote-icon" currency={quoteAssetTicker || ''} size={16} />
                 </span>
-                {`Swap ${baseAssetTicker} for ${quoteAssetTicker}`}
+                {`Swap ${baseAssetTickerFormatted} for ${quoteAssetTickerFormatted}`}
               </td>
               <td>{quoteAmount}</td>
-              <td>{`${baseAmount} ${baseAssetTicker}`}</td>
-              <td>{`${quoteAmount} ${quoteAssetTicker}`}</td>
+              <td>{`${baseAmount} ${baseAssetTickerFormatted}`}</td>
+              <td>{`${quoteAmount} ${quoteAssetTickerFormatted}`}</td>
               <td data-time={settleTimeUnix}>{timeAgo(settleTimeUnix)}</td>
               <td>
                 <RightOutlined />

--- a/src/features/operator/TxsTable/WithdrawalRows.tsx
+++ b/src/features/operator/TxsTable/WithdrawalRows.tsx
@@ -6,8 +6,7 @@ import type { Withdrawal, MarketInfo } from '../../../api-spec/generated/js/oper
 import { ReactComponent as depositIcon } from '../../../assets/images/deposit.svg';
 import type { Asset } from '../../../domain/asset';
 import type { LbtcUnit } from '../../../utils';
-import { assetIdToTicker, timeAgo } from '../../../utils';
-import { formatSatsToUnit } from '../../../utils/unitConvert';
+import { assetIdToTicker, isLbtc, timeAgo, formatSatsToUnit } from '../../../utils';
 import { useGetTransactionByIdQuery } from '../../liquid.api';
 
 interface WithdrawalRowsProps {
@@ -47,6 +46,8 @@ const WithdrawRow = ({
       ? 'N/A'
       : formatSatsToUnit(balance?.quoteAmount, lbtcUnit, baseAssetId);
   const time = timestampUnix || tx?.status.block_time;
+  const baseAssetTickerFormatted = isLbtc(baseAssetTicker) ? lbtcUnit : baseAssetTicker;
+  const quoteAssetTickerFormatted = isLbtc(quoteAssetTicker) ? lbtcUnit : quoteAssetTicker;
   return (
     <>
       <tr
@@ -57,11 +58,11 @@ const WithdrawRow = ({
       >
         <td>
           <Icon component={depositIcon} className="rotate-icon tx-icon" />
-          {`Withdraw ${baseAssetTicker}`}
+          {`Withdraw ${baseAssetTickerFormatted}`}
         </td>
         <td>{baseAmount}</td>
-        <td>{`${baseAmount} ${baseAssetTicker}`}</td>
-        <td>{`${quoteAmount} ${quoteAssetTicker}`}</td>
+        <td>{`${baseAmount} ${baseAssetTickerFormatted}`}</td>
+        <td>{`${quoteAmount} ${quoteAssetTickerFormatted}`}</td>
         <td data-time={time}>{timeAgo(time)}</td>
         <td>
           <RightOutlined />

--- a/src/utils/asset.ts
+++ b/src/utils/asset.ts
@@ -1,6 +1,12 @@
 import type { Asset } from '../domain/asset';
 
+import { LBTC_TESTNET_TICKER, LBTC_TICKER } from './constants';
+
 export const assetIdToTicker = (assetId: string, assets: Asset[]): string => {
   const asset = assets.find((a: Asset) => a.asset_id === assetId);
   return asset?.ticker || assetId.substring(0, 4).toUpperCase();
+};
+
+export const isLbtc = (ticker: string): boolean => {
+  return ticker === LBTC_TICKER || ticker === LBTC_TESTNET_TICKER;
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -75,5 +75,5 @@ export const featuredAssets: Asset[] = [LBTC_ASSET, USDT_ASSET, LCAD_ASSET];
 
 export const isAssetBitcoin = (asset: string): boolean => asset === LBTC_ASSET.asset_id;
 
-export const LBTC_UNITS = ['btc', 'mBtc', 'bits', 'sats'] as const;
+export const LBTC_UNITS = ['L-BTC', 'mBTC', 'Bits', 'Sats'] as const;
 export type LbtcUnit = typeof LBTC_UNITS[number];

--- a/src/utils/unitConvert.ts
+++ b/src/utils/unitConvert.ts
@@ -29,19 +29,49 @@ export function formatSatsToUnit(sats: number, unit: LbtcUnit, asset?: string): 
       return removeInsignificant(val.toFixed(8));
     }
     switch (unit) {
-      case 'btc':
+      case 'L-BTC':
         val.e = exp - 8;
         return removeInsignificant(val.toFixed(8));
-      case 'mBtc':
+      case 'mBTC':
         val.e = exp - 5;
-        return removeInsignificant(val.toFixed(8));
-      case 'bits':
+        return removeInsignificant(val.toFixed(5));
+      case 'Bits':
         val.e = exp - 2;
-        return removeInsignificant(val.toFixed(8));
-      case 'sats':
-        return removeInsignificant(sats.toFixed(8));
+        return removeInsignificant(val.toFixed(2));
+      case 'Sats':
+        return removeInsignificant(val.toFixed(0));
       default:
-        return removeInsignificant(sats.toFixed(8));
+        return removeInsignificant(val.toFixed(0));
+    }
+  } catch (err) {
+    console.error(err);
+    return 'N/A';
+  }
+}
+
+/**
+ * Format any lbtc unit to sats
+ * @param amount
+ * @param unit
+ */
+export function formatLbtcUnitToSats(amount: number, unit: LbtcUnit): string {
+  try {
+    const val = new Big(amount);
+    const exp = val.e;
+    switch (unit) {
+      case 'L-BTC':
+        val.e = exp + 8;
+        return removeInsignificant(val.toFixed(8));
+      case 'mBTC':
+        val.e = exp + 5;
+        return removeInsignificant(val.toFixed(5));
+      case 'Bits':
+        val.e = exp + 2;
+        return removeInsignificant(val.toFixed(2));
+      case 'Sats':
+        return removeInsignificant(val.toFixed(0));
+      default:
+        return removeInsignificant(val.toFixed(0));
     }
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
In market withdraw, expect lbtc amount to be inputted in favorite user unit.
In table, display LBTC unit instead of hardcoded LBTC ticker.