### PR TITLE
Proxy: fix status codes

### DIFF
--- a/rpc_proxy.go
+++ b/rpc_proxy.go
@@ -28,14 +28,14 @@ import (
 )
 
 const (
+	statusServing serviceState = iota
+	statusNotConnected
+	statusNotServing
+
 	defaultConnectTimeout = 15 * time.Second
 	defaultServerTimeout  = 10 * time.Second
 	defaultServerAddr     = ":3030"
 	defaultLogToFile      = false
-
-	statusServing serviceState = iota
-	statusNotConnected
-	statusNotServing
 )
 
 var (


### PR DESCRIPTION
This fixes the codes of the statuses returned by the ` /healthcheck` endpoint of the proxy.

Closes #178.

Please @tiero @Janaka-Steph review this.