### PR TITLE
Redirect to CreateOrRestore if paired with not init daemon

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -152,7 +152,7 @@ export const App = (): JSX.Element => {
   return (
     <>
       <Shell>
-        <Routes />
+        <Routes setIsServiceUnavailableModalVisible={setIsServiceUnavailableModalVisible} />
         <ServiceUnavailableModal
           isServiceUnavailableModalVisible={isServiceUnavailableModalVisible}
           setIsServiceUnavailableModalVisible={setIsServiceUnavailableModalVisible}

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -37,16 +37,16 @@ export const Home = (): JSX.Element => {
 
   useEffect(() => {
     if (proxyHealth === 'SERVING') {
-      if (isReady?.isInitialized) {
+      if (isReady?.initialized) {
         setProxyIsServingAndReady(true);
       } else {
         refetchIsReady();
       }
     }
-  }, [isReady?.isInitialized, proxyHealth, refetchIsReady]);
+  }, [isReady?.initialized, proxyHealth, refetchIsReady]);
 
   useEffect(() => {
-    if (isReady?.isInitialized && !isReady?.isUnlocked) {
+    if (isReady?.initialized && !isReady?.unlocked) {
       showUnlockWalletModal();
     }
   }, [isReady]);

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -20,7 +20,7 @@ export const Home = (): JSX.Element => {
     refetch: refetchIsReady,
     error: errorIsReady,
   } = useIsReadyQuery(undefined, {
-    // Skip if proxy is used and not serving
+    // Skip if proxy is used but not serving
     skip: proxyHealth && proxyHealth !== 'SERVING',
   });
   // UnlockWallet Modal

--- a/src/features/settings/Settings.tsx
+++ b/src/features/settings/Settings.tsx
@@ -4,6 +4,7 @@ import { Breadcrumb, Row, Col, Typography, Button, Radio, notification } from 'a
 import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
+import type { RootState } from '../../app/store';
 import { useTypedDispatch, useTypedSelector } from '../../app/store';
 import { ReactComponent as chevronRight } from '../../assets/images/chevron-right.svg';
 import { HOME_ROUTE, MARKET_WITHDRAW_FRAGMENTER_ROUTE } from '../../routes/constants';
@@ -22,15 +23,10 @@ const { Text, Title } = Typography;
 export const Settings = (): JSX.Element => {
   const navigate = useNavigate();
   const dispatch = useTypedDispatch();
-  const { tdexdConnectUrl, lbtcUnit, useProxy } = useTypedSelector(({ settings }) => ({
-    tdexdConnectUrl: settings.tdexdConnectUrl,
-    lbtcUnit: settings.lbtcUnit,
-    useProxy: settings.useProxy,
-  }));
+  const { tdexdConnectUrl, lbtcUnit, useProxy } = useTypedSelector(({ settings }: RootState) => settings);
   const [reloadUtxos, { isLoading: isReloadUtxosLoading }] = useReloadUtxosMutation();
-  const handleBitcoinUnitChange = async (ev: RadioChangeEvent) => {
-    dispatch(setLbtcUnit(ev.target.value));
-  };
+
+  const handleBitcoinUnitChange = (ev: RadioChangeEvent) => dispatch(setLbtcUnit(ev.target.value));
 
   return (
     <>

--- a/src/features/settings/Settings.tsx
+++ b/src/features/settings/Settings.tsx
@@ -8,7 +8,10 @@ import { useTypedDispatch, useTypedSelector } from '../../app/store';
 import { ReactComponent as chevronRight } from '../../assets/images/chevron-right.svg';
 import { HOME_ROUTE, MARKET_WITHDRAW_FRAGMENTER_ROUTE } from '../../routes/constants';
 import { LBTC_UNITS } from '../../utils';
-import { useReloadUtxosMutation } from '../operator/operator.api';
+import { liquidApi } from '../liquid.api';
+import { operatorApi, useReloadUtxosMutation } from '../operator/operator.api';
+import { walletApi } from '../wallet/wallet.api';
+import { walletUnlockerApi } from '../walletUnlocker/walletUnlocker.api';
 
 import { ExplorersLiquidApiForm } from './ExplorersLiquidApiForm';
 import { ExplorersLiquidUiForm } from './ExplorersLiquidUiForm';
@@ -79,7 +82,12 @@ export const Settings = (): JSX.Element => {
                         console.error(err);
                       }
                     }
-                    await dispatch(logout());
+                    dispatch(logout());
+                    // Reset the APIs state completely
+                    dispatch(liquidApi.util.resetApiState());
+                    dispatch(operatorApi.util.resetApiState());
+                    dispatch(walletUnlockerApi.util.resetApiState());
+                    dispatch(walletApi.util.resetApiState());
                   }}
                   className="w-100"
                 >
@@ -109,7 +117,12 @@ export const Settings = (): JSX.Element => {
                         console.error(err);
                       }
                     }
-                    await dispatch(resetSettings());
+                    dispatch(resetSettings());
+                    // Reset the APIs state completely
+                    dispatch(liquidApi.util.resetApiState());
+                    dispatch(operatorApi.util.resetApiState());
+                    dispatch(walletUnlockerApi.util.resetApiState());
+                    dispatch(walletApi.util.resetApiState());
                   }}
                 >
                   Clear Cache

--- a/src/features/walletUnlocker/OnboardingPairing.tsx
+++ b/src/features/walletUnlocker/OnboardingPairing.tsx
@@ -1,6 +1,6 @@
 import './onboardingPairing.less';
 import { Button, Col, Form, Input, Modal, notification, Row, Typography } from 'antd';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useTypedDispatch } from '../../app/store';
@@ -11,7 +11,12 @@ import {
   downloadCert,
   extractHostCertMacaroon,
 } from '../../utils/connect';
+import { liquidApi } from '../liquid.api';
+import { operatorApi } from '../operator/operator.api';
 import { setBaseUrl, setMacaroonCredentials, setTdexdConnectUrl } from '../settings/settingsSlice';
+import { walletApi } from '../wallet/wallet.api';
+
+import { walletUnlockerApi } from './walletUnlocker.api';
 
 const { Title } = Typography;
 
@@ -26,6 +31,16 @@ export const OnboardingPairing = (): JSX.Element => {
   const [isDownloadCertModalVisible, setIsDownloadCertModalVisible] = useState<boolean>(false);
   const navigate = useNavigate();
   const dispatch = useTypedDispatch();
+
+  useEffect(() => {
+    // Reset the APIs state completely
+    // Especially useful when redirected on this page after failed pairing attempt
+    dispatch(liquidApi.util.resetApiState());
+    dispatch(operatorApi.util.resetApiState());
+    dispatch(walletUnlockerApi.util.resetApiState());
+    dispatch(walletApi.util.resetApiState());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onFinish = async () => {
     try {

--- a/src/features/walletUnlocker/walletUnlocker.api.ts
+++ b/src/features/walletUnlocker/walletUnlocker.api.ts
@@ -7,6 +7,7 @@ import type {
   InitWalletReply,
   ChangePasswordReply,
   UnlockWalletReply,
+  IsReadyReply,
 } from '../../api-spec/generated/js/walletunlocker_pb';
 import {
   ChangePasswordRequest,
@@ -101,11 +102,7 @@ const baseQueryFn: BaseQueryFn<
       try {
         const isReadyReply = await client.isReady(new IsReadyRequest(), metadata);
         return {
-          data: {
-            isUnlocked: isReadyReply.getUnlocked(),
-            isInitialized: isReadyReply.getInitialized(),
-            isSynced: isReadyReply.getSynced(),
-          },
+          data: isReadyReply.toObject(false),
         };
       } catch (error) {
         console.error(error);
@@ -155,14 +152,7 @@ export const walletUnlockerApi = createApi({
       query: (body) => ({ methodName: 'changePassword', body }),
       invalidatesTags: ['Unlocker'],
     }),
-    isReady: build.query<
-      {
-        isUnlocked: boolean;
-        isInitialized: boolean;
-        isSynced: boolean;
-      },
-      void
-    >({
+    isReady: build.query<IsReadyReply.AsObject, void>({
       query: () => ({ methodName: 'isReady' }),
       providesTags: ['Unlocker'],
     }),

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -35,10 +35,19 @@ import {
 } from './constants';
 
 const PrivateRoute = ({ children }: any) => {
-  const isOnboarded = useTypedSelector(
+  const isFullyOnboarded = useTypedSelector(
     ({ settings }) => !!(settings.macaroonCredentials && settings.tdexdConnectUrl)
   );
-  return isOnboarded ? children : <Navigate to={ONBOARDING_PAIRING_ROUTE} />;
+  const isPairedWithNotInitDaemon = useTypedSelector(
+    ({ settings }) => !!(!settings.macaroonCredentials && settings.tdexdConnectUrl)
+  );
+  return isFullyOnboarded ? (
+    children
+  ) : isPairedWithNotInitDaemon ? (
+    <Navigate to={ONBOARDING_CREATE_OR_RESTORE_ROUTE} />
+  ) : (
+    <Navigate to={ONBOARDING_PAIRING_ROUTE} />
+  );
 };
 
 export const Routes = (): JSX.Element => {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { Navigate, Route, Routes as ReactRouterDomRoutes } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { Navigate, Route, Routes as ReactRouterDomRoutes, useNavigate } from 'react-router-dom';
 
 import type { IsReadyReply } from '../api-spec/generated/js/walletunlocker_pb';
 import type { RootState } from '../app/store';
-import { useTypedSelector } from '../app/store';
+import { useTypedDispatch, useTypedSelector } from '../app/store';
 import { Home } from '../features/home/Home';
 import { FeeDeposit } from '../features/operator/Fee/FeeDeposit';
 import { FeeWithdraw } from '../features/operator/Fee/FeeWithdraw';
@@ -13,6 +13,7 @@ import { MarketFragmenterWithdraw } from '../features/operator/Market/MarketFrag
 import { MarketOverview } from '../features/operator/Market/MarketOverview';
 import { MarketWithdraw } from '../features/operator/Market/MarketWithdraw';
 import { Settings } from '../features/settings/Settings';
+import { disconnectProxy, logout } from '../features/settings/settingsSlice';
 import { OnboardingConfirmMnemonic } from '../features/walletUnlocker/OnboardingConfirmMnemonic';
 import { OnboardingCreateOrRestore } from '../features/walletUnlocker/OnboardingCreateOrRestore';
 import { OnboardingPairing } from '../features/walletUnlocker/OnboardingPairing';
@@ -41,7 +42,7 @@ const PrivateRoute = ({ children }: any) => {
   const tdexdConnectUrl = useTypedSelector(({ settings }: RootState) => settings.tdexdConnectUrl);
   const isDaemonInitialized = useTypedSelector(
     ({ walletUnlockerService }: RootState) =>
-      (walletUnlockerService.queries['isReady(undefined)']?.data as IsReadyReply.AsObject).initialized
+      (walletUnlockerService.queries['isReady(undefined)']?.data as IsReadyReply.AsObject)?.initialized
   );
   if (isDaemonInitialized && tdexdConnectUrl) {
     return children;
@@ -54,94 +55,117 @@ const PrivateRoute = ({ children }: any) => {
   }
 };
 
-export const Routes = (): JSX.Element => {
-  // If tdexdConnectUrl, call IsReady to set data in store
-  const tdexdConnectUrl = useTypedSelector(({ settings }: RootState) => settings.tdexdConnectUrl);
-  const { data: isReadyData } = useIsReadyQuery(undefined, { skip: !tdexdConnectUrl });
+interface RoutesProps {
+  setIsServiceUnavailableModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
+}
 
-  return isReadyData ? (
+export const Routes = ({ setIsServiceUnavailableModalVisible }: RoutesProps): JSX.Element => {
+  const navigate = useNavigate();
+  const dispatch = useTypedDispatch();
+  // If tdexdConnectUrl, call IsReady to set data in store
+  const { tdexdConnectUrl, proxyHealth, useProxy } = useTypedSelector(({ settings }: RootState) => settings);
+  const { isSuccess, isError } = useIsReadyQuery(undefined, {
+    // Skip if no tdexdConnectUrl or if proxy is used but not serving
+    skip: !tdexdConnectUrl || (proxyHealth && proxyHealth !== 'SERVING'),
+  });
+
+  useEffect(() => {
+    (async () => {
+      if (isError) {
+        navigate(ONBOARDING_PAIRING_ROUTE);
+        setIsServiceUnavailableModalVisible(true);
+        dispatch(logout());
+        if (useProxy) {
+          await dispatch(disconnectProxy()).unwrap();
+        }
+      }
+    })();
+  }, [dispatch, isError, navigate, setIsServiceUnavailableModalVisible, useProxy]);
+
+  return (
     <ReactRouterDomRoutes>
-      <Route
-        path={HOME_ROUTE}
-        element={
-          <PrivateRoute>
-            <Home />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path={MARKET_OVERVIEW_ROUTE}
-        element={
-          <PrivateRoute>
-            <MarketOverview />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path={SETTINGS_ROUTE}
-        element={
-          <PrivateRoute>
-            <Settings />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path={FEE_DEPOSIT_ROUTE}
-        element={
-          <PrivateRoute>
-            <FeeDeposit />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path={FEE_WITHDRAW_ROUTE}
-        element={
-          <PrivateRoute>
-            <FeeWithdraw />
-          </PrivateRoute>
-        }
-      />
-      {/* Market */}
-      <Route
-        path={CREATE_MARKET_ROUTE}
-        element={
-          <PrivateRoute>
-            <CreateMarket />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path={MARKET_DEPOSIT_ROUTE}
-        element={
-          <PrivateRoute>
-            <MarketDeposit />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path={MARKET_WITHDRAW_ROUTE}
-        element={
-          <PrivateRoute>
-            <MarketWithdraw />
-          </PrivateRoute>
-        }
-      />
-      <Route
-        path={MARKET_WITHDRAW_FRAGMENTER_ROUTE}
-        element={
-          <PrivateRoute>
-            <MarketFragmenterWithdraw />
-          </PrivateRoute>
-        }
-      />
       {/* Onboarding Routes*/}
       <Route path={ONBOARDING_PAIRING_ROUTE} element={<OnboardingPairing />} />
       <Route path={ONBOARDING_CREATE_OR_RESTORE_ROUTE} element={<OnboardingCreateOrRestore />} />
       <Route path={ONBOARDING_RESTORE_MNEMONIC_ROUTE} element={<OnboardingRestoreMnemonic />} />
       <Route path={ONBOARDING_SHOW_MNEMONIC_ROUTE} element={<OnboardingShowMnemonic />} />
       <Route path={ONBOARDING_CONFIRM_MNEMONIC_ROUTE} element={<OnboardingConfirmMnemonic />} />
+      {(isSuccess || !tdexdConnectUrl) && (
+        <>
+          <Route
+            path={HOME_ROUTE}
+            element={
+              <PrivateRoute>
+                <Home />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path={MARKET_OVERVIEW_ROUTE}
+            element={
+              <PrivateRoute>
+                <MarketOverview />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path={SETTINGS_ROUTE}
+            element={
+              <PrivateRoute>
+                <Settings />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path={FEE_DEPOSIT_ROUTE}
+            element={
+              <PrivateRoute>
+                <FeeDeposit />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path={FEE_WITHDRAW_ROUTE}
+            element={
+              <PrivateRoute>
+                <FeeWithdraw />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path={CREATE_MARKET_ROUTE}
+            element={
+              <PrivateRoute>
+                <CreateMarket />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path={MARKET_DEPOSIT_ROUTE}
+            element={
+              <PrivateRoute>
+                <MarketDeposit />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path={MARKET_WITHDRAW_ROUTE}
+            element={
+              <PrivateRoute>
+                <MarketWithdraw />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path={MARKET_WITHDRAW_FRAGMENTER_ROUTE}
+            element={
+              <PrivateRoute>
+                <MarketFragmenterWithdraw />
+              </PrivateRoute>
+            }
+          />
+        </>
+      )}
     </ReactRouterDomRoutes>
-  ) : (
-    <></>
   );
 };


### PR DESCRIPTION
Redirect to CreateOrRestore page if paired with not initialized daemon, based on isReady response.
User can still nagivate to pairing page using the breadcrumb if he wants to.

It closes #86 

Please review @tiero 