### PR TITLE
Remove localStorage before quitting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,8 @@ export const App = (): JSX.Element => {
       if (proxyChildProcess.current?.pid && isExiting && proxyHealth === 'NOT_SERVING') {
         // Need to sleep the time to write in persistent storage
         await sleep(250);
+        // Delete local storage to avoid rehydration issues
+        localStorage.removeItem('persist:root');
         await proxyChildProcess.current?.kill();
         await exit();
       }


### PR DESCRIPTION
To avoid rehydration issues we make sure the only persisted state comes from filesystem.  