### PR TITLE
When on Tauri use tauriStorage only

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,8 +57,6 @@ export const App = (): JSX.Element => {
       if (proxyChildProcess.current?.pid && isExiting && proxyHealth === 'NOT_SERVING') {
         // Need to sleep the time to write in persistent storage
         await sleep(250);
-        // Delete local storage to avoid rehydration issues
-        localStorage.removeItem('persist:root');
         await proxyChildProcess.current?.kill();
         await exit();
       }

--- a/src/app/rootReducer.ts
+++ b/src/app/rootReducer.ts
@@ -2,18 +2,12 @@ import { combineReducers } from '@reduxjs/toolkit';
 
 import { liquidApi } from '../features/liquid.api';
 import { operatorApi } from '../features/operator/operator.api';
-import type { SettingsState } from '../features/settings/settingsSlice';
 import { settingsSlice } from '../features/settings/settingsSlice';
 import { walletApi } from '../features/wallet/wallet.api';
 import { walletUnlockerApi } from '../features/walletUnlocker/walletUnlocker.api';
-import { persist } from '../utils/storage';
 
 export const rootReducer = combineReducers({
-  settings: persist<SettingsState>({
-    reducer: settingsSlice.reducer,
-    key: settingsSlice.name,
-    version: 0,
-  }),
+  [settingsSlice.name]: settingsSlice.reducer,
   [liquidApi.reducerPath]: liquidApi.reducer,
   [operatorApi.reducerPath]: operatorApi.reducer,
   [walletUnlockerApi.reducerPath]: walletUnlockerApi.reducer,

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -3,20 +3,21 @@ import { configureStore } from '@reduxjs/toolkit';
 import type { TypedUseSelectorHook } from 'react-redux';
 import { useDispatch, useSelector } from 'react-redux';
 import { persistStore, persistReducer } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
+import localStorage from 'redux-persist/lib/storage';
 
 import { liquidApi } from '../features/liquid.api';
 import { operatorApi } from '../features/operator/operator.api';
 import { walletApi } from '../features/wallet/wallet.api';
 import { walletUnlockerApi } from '../features/walletUnlocker/walletUnlocker.api';
+import { tauriStorage } from '../utils';
 
 import { rootReducer } from './rootReducer';
 
 // Persist all except API slices in order to persist Settings
 const persistConfig = {
   key: 'root',
-  version: 1,
-  storage,
+  version: 0,
+  storage: '__TAURI__' in window ? tauriStorage : localStorage,
   blacklist: [
     liquidApi.reducerPath,
     operatorApi.reducerPath,

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -37,7 +37,7 @@ export const tauriStorage: Storage = {
   },
 };
 
-function createLocalStorageConfig<S>(
+function createTauriStorageConfig<S>(
   key: string,
   whitelist?: string[],
   blacklist?: string[],
@@ -61,7 +61,7 @@ export function persist<S>(opts: {
   version?: number;
 }): Reducer<S & PersistPartial, Action> {
   return persistReducer<S, Action>(
-    createLocalStorageConfig(opts.key, opts.whitelist, opts.blacklist, opts.version),
+    createTauriStorageConfig(opts.key, opts.whitelist, opts.blacklist, opts.version),
     opts.reducer
   );
 }


### PR DESCRIPTION
Two PersistConfig where used, one produced by the `persist` in `src/utils/storage.ts` (the one used by Tauri FS) and the other in `src/app/store.ts` (also used in Tauri app as local storage).
This PR remove the use of `persist` function on the settings reducer. Instead we check if it's Tauri app and pass the proper PersistConfig.
