### PR TITLE
Refactor formatSatsToUnit to take into account asset precision

### DIFF
--- a/src/domain/asset.ts
+++ b/src/domain/asset.ts
@@ -4,4 +4,7 @@ export type Asset = {
   name: string;
   precision: number;
   coinGeckoID?: string;
+  // Used when we want to display either the asset ticker or LBTC unit
+  // Used in fromSatoshiToUnitOrFractional() to determine if asset is LBTC or not
+  unitOrTicker?: string;
 };

--- a/src/features/home/DashboardPanelLeft.tsx
+++ b/src/features/home/DashboardPanelLeft.tsx
@@ -5,11 +5,9 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import type { Market } from '../../api-spec/generated/js/types_pb';
-import type { RootState } from '../../app/store';
-import { useTypedSelector } from '../../app/store';
 import { CREATE_MARKET_ROUTE } from '../../routes/constants';
 import type { LbtcUnit } from '../../utils';
-import { formatSatsToUnit, LBTC_ASSET } from '../../utils';
+import { fromSatoshiToUnitOrFractional } from '../../utils';
 import { useListMarketsQuery, useTotalCollectedSwapFeesQuery } from '../operator/operator.api';
 
 const { Title } = Typography;
@@ -20,7 +18,6 @@ interface DashboardPanelLeftProps {
 
 export const DashboardPanelLeft = ({ lbtcUnit }: DashboardPanelLeftProps): JSX.Element => {
   const navigate = useNavigate();
-  const { network } = useTypedSelector(({ settings }: RootState) => settings);
   const { data: listMarkets } = useListMarketsQuery();
   const activeMarkets = listMarkets?.marketsList.filter((m) => m.tradable).length || 0;
   const pausedMarkets = (listMarkets?.marketsList.length ?? 0) - activeMarkets;
@@ -37,7 +34,7 @@ export const DashboardPanelLeft = ({ lbtcUnit }: DashboardPanelLeftProps): JSX.E
         <Col className="dm-mono dm-mono__xxxxxx" span={12}>
           {totalCollectedSwapFees === undefined
             ? 'N/A'
-            : formatSatsToUnit(totalCollectedSwapFees, lbtcUnit, LBTC_ASSET[network].asset_id, network)}
+            : fromSatoshiToUnitOrFractional(totalCollectedSwapFees, 8, lbtcUnit)}
         </Col>
         <Col className="total-earned-change" span={12}>
           <div>24h</div>

--- a/src/features/home/DashboardPanelRight.tsx
+++ b/src/features/home/DashboardPanelRight.tsx
@@ -3,12 +3,10 @@ import Icon from '@ant-design/icons';
 import { Button, Col, Row, Typography } from 'antd';
 import { useNavigate } from 'react-router-dom';
 
-import type { RootState } from '../../app/store';
-import { useTypedSelector } from '../../app/store';
 import { ReactComponent as depositIcon } from '../../assets/images/deposit-green.svg';
 import { FEE_DEPOSIT_ROUTE, FEE_WITHDRAW_ROUTE } from '../../routes/constants';
 import type { LbtcUnit } from '../../utils';
-import { formatSatsToUnit, LBTC_ASSET } from '../../utils';
+import { fromSatoshiToUnitOrFractional } from '../../utils';
 import { useGetFeeBalanceQuery } from '../operator/operator.api';
 
 const { Title } = Typography;
@@ -19,7 +17,6 @@ interface DashboardPanelRightProps {
 
 export const DashboardPanelRight = ({ lbtcUnit }: DashboardPanelRightProps): JSX.Element => {
   const navigate = useNavigate();
-  const { network } = useTypedSelector(({ settings }: RootState) => settings);
   const { data: feeBalance } = useGetFeeBalanceQuery();
 
   return (
@@ -31,7 +28,7 @@ export const DashboardPanelRight = ({ lbtcUnit }: DashboardPanelRightProps): JSX
         <Col className="dm-mono dm-mono__xxxxxx" span={24}>
           {feeBalance?.totalBalance === undefined
             ? 'N/A'
-            : formatSatsToUnit(feeBalance?.totalBalance, lbtcUnit, LBTC_ASSET[network].asset_id, network)}
+            : fromSatoshiToUnitOrFractional(feeBalance?.totalBalance, 8, lbtcUnit)}
         </Col>
       </Row>
       <Row gutter={{ xs: 8, sm: 12, md: 16 }}>

--- a/src/features/liquid.api.ts
+++ b/src/features/liquid.api.ts
@@ -3,7 +3,15 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
 import type { RootState } from '../app/store';
 import type { Asset } from '../domain/asset';
-import { isLbtcAssetId, isLcadAssetId, isUsdtAssetId, LBTC_ASSET, LCAD_ASSET, USDT_ASSET } from '../utils';
+import {
+  isLbtcAssetId,
+  isLbtcTicker,
+  isLcadAssetId,
+  isUsdtAssetId,
+  LBTC_ASSET,
+  LCAD_ASSET,
+  USDT_ASSET,
+} from '../utils';
 
 const dynamicBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> = async (
   args,
@@ -30,7 +38,12 @@ export const liquidApi = createApi({
           if (!arg) throw new Error('no argument provided');
           // Checking if asset is LBTC because Esplora 'asset' endpoint does not return ticker for LBTC
           const { settings } = api.getState() as RootState;
-          if (isLbtcAssetId(arg, settings.network)) return { data: LBTC_ASSET[settings.network] };
+          if (isLbtcAssetId(arg, settings.network))
+            return {
+              data: Object.assign({}, LBTC_ASSET[settings.network], {
+                unitOrTicker: settings.lbtcUnit,
+              }),
+            };
           if (isUsdtAssetId(arg, settings.network)) return { data: USDT_ASSET[settings.network] };
           if (isLcadAssetId(arg, settings.network)) return { data: LCAD_ASSET[settings.network] };
           const res = (await baseQuery(`asset/${arg}`)) as { data: Asset };
@@ -41,7 +54,8 @@ export const liquidApi = createApi({
             res.data.ticker = res.data?.asset_id.substring(0, 4).toUpperCase();
           }
           const { ticker, asset_id, name, precision } = res.data;
-          return { data: { ticker, asset_id, name, precision } };
+          const unitOrTicker = isLbtcTicker(ticker) ? settings.lbtcUnit : ticker;
+          return { data: { ticker, asset_id, name, precision, unitOrTicker } };
         } catch (err) {
           return { error: err as FetchBaseQueryError };
         }

--- a/src/features/operator/Fee/FeeForm/index.tsx
+++ b/src/features/operator/Fee/FeeForm/index.tsx
@@ -12,7 +12,7 @@ import type { Asset } from '../../../../domain/asset';
 import {
   formatFiatToSats,
   formatLbtcUnitToSats,
-  formatSatsToUnit,
+  fromSatoshiToUnitOrFractional,
   isLbtcAssetId,
   sleep,
 } from '../../../../utils';
@@ -63,8 +63,6 @@ export const FeeForm = ({
     baseAsset: baseAsset.asset_id,
     quoteAsset: quoteAsset.asset_id,
   });
-  const baseAssetUnitOrTicker = isLbtcAssetId(baseAsset.asset_id, network) ? lbtcUnit : baseAsset.ticker;
-  const quoteAssetUnitOrTicker = isLbtcAssetId(quoteAsset.asset_id, network) ? lbtcUnit : quoteAsset.ticker;
 
   const onFinish = async () => {
     try {
@@ -101,17 +99,15 @@ export const FeeForm = ({
   const resetAll = async () => {
     if (!marketInfo?.fee?.fixed) return;
     form.setFieldsValue({
-      feeAbsoluteBaseInput: formatSatsToUnit(
+      feeAbsoluteBaseInput: fromSatoshiToUnitOrFractional(
         marketInfo.fee.fixed.baseFee,
-        lbtcUnit,
-        baseAsset.asset_id,
-        network
+        baseAsset.precision,
+        baseAsset.unitOrTicker ?? ''
       ),
-      feeAbsoluteQuoteInput: formatSatsToUnit(
+      feeAbsoluteQuoteInput: fromSatoshiToUnitOrFractional(
         marketInfo.fee.fixed.quoteFee,
-        lbtcUnit,
-        quoteAsset.asset_id,
-        network
+        quoteAsset.precision,
+        quoteAsset.unitOrTicker ?? ''
       ),
       feeRelativeInput: String(marketInfo.fee.basisPoint / 100),
     });
@@ -123,17 +119,15 @@ export const FeeForm = ({
       form={form}
       name="fee_form"
       initialValues={{
-        feeAbsoluteBaseInput: formatSatsToUnit(
+        feeAbsoluteBaseInput: fromSatoshiToUnitOrFractional(
           Number(feeAbsoluteBase),
-          lbtcUnit,
-          baseAsset.asset_id,
-          network
+          baseAsset.precision,
+          baseAsset.unitOrTicker ?? ''
         ),
-        feeAbsoluteQuoteInput: formatSatsToUnit(
+        feeAbsoluteQuoteInput: fromSatoshiToUnitOrFractional(
           Number(feeAbsoluteQuote),
-          lbtcUnit,
-          quoteAsset.asset_id,
-          network
+          quoteAsset.precision,
+          quoteAsset.unitOrTicker ?? ''
         ),
         feeRelativeInput: Number(feeRelative) / 100,
       }}
@@ -152,13 +146,13 @@ export const FeeForm = ({
         <Row align="middle">
           <Col span={8}>
             <CurrencyIcon currency={baseAsset.ticker} />
-            <span className="dm-sans dm-sans__xx ml-2">{baseAssetUnitOrTicker}</span>
+            <span className="dm-sans dm-sans__xx ml-2">{baseAsset.unitOrTicker ?? ''}</span>
           </Col>
           <Col span={16}>
             <InputAmount
               assetPrecision={baseAsset.precision}
               formItemName="feeAbsoluteBaseInput"
-              lbtcUnitOrTicker={baseAssetUnitOrTicker}
+              lbtcUnitOrTicker={baseAsset.unitOrTicker ?? ''}
               setInputValue={(value) => form.setFieldsValue({ feeAbsoluteBaseInput: value })}
             />
           </Col>
@@ -175,7 +169,7 @@ export const FeeForm = ({
             <InputAmount
               assetPrecision={quoteAsset.precision}
               formItemName="feeAbsoluteQuoteInput"
-              lbtcUnitOrTicker={quoteAssetUnitOrTicker}
+              lbtcUnitOrTicker={quoteAsset.unitOrTicker ?? ''}
               setInputValue={(value) => form.setFieldsValue({ feeAbsoluteQuoteInput: value })}
             />
           </Col>

--- a/src/features/operator/Fee/FeeWithdraw/index.tsx
+++ b/src/features/operator/Fee/FeeWithdraw/index.tsx
@@ -11,7 +11,7 @@ import { ReactComponent as chevronRight } from '../../../../assets/images/chevro
 import { CurrencyIcon } from '../../../../common/CurrencyIcon';
 import { InputAmount } from '../../../../common/InputAmount';
 import { HOME_ROUTE } from '../../../../routes/constants';
-import { formatLbtcUnitToSats, formatSatsToUnit, LBTC_ASSET, LBTC_TICKER } from '../../../../utils';
+import { formatLbtcUnitToSats, fromSatoshiToUnitOrFractional, LBTC_TICKER } from '../../../../utils';
 import { useGetFeeBalanceQuery, useWithdrawFeeMutation } from '../../operator.api';
 
 interface IFormInputs {
@@ -30,11 +30,11 @@ export const FeeWithdraw = (): JSX.Element => {
   const feeAvailableBalanceFormatted =
     feeBalance?.availableBalance === undefined
       ? 'N/A'
-      : formatSatsToUnit(feeBalance?.availableBalance, lbtcUnit, LBTC_ASSET[network].asset_id, network);
+      : fromSatoshiToUnitOrFractional(feeBalance?.availableBalance, 8, lbtcUnit);
   const feeTotalBalanceFormatted =
     feeBalance?.totalBalance === undefined
       ? 'N/A'
-      : formatSatsToUnit(feeBalance?.totalBalance, lbtcUnit, LBTC_ASSET[network].asset_id, network);
+      : fromSatoshiToUnitOrFractional(feeBalance?.totalBalance, 8, lbtcUnit);
 
   const onFinish = async () => {
     try {

--- a/src/features/operator/Market/MarketOverview/VolumePanel.tsx
+++ b/src/features/operator/Market/MarketOverview/VolumePanel.tsx
@@ -6,7 +6,7 @@ import { useTypedSelector } from '../../../../app/store';
 import { CurrencyIcon } from '../../../../common/CurrencyIcon';
 import { VolumeChart } from '../../../../common/VolumeChart';
 import type { Asset } from '../../../../domain/asset';
-import { formatCompact, formatSatsToUnit, isLbtcAssetId } from '../../../../utils';
+import { formatCompact, fromSatoshiToUnitOrFractional, isLbtcAssetId } from '../../../../utils';
 
 interface VolumePanelProps {
   baseAsset: Asset;
@@ -22,11 +22,20 @@ export const VolumePanel = ({ baseAsset, quoteAsset, marketInfo }: VolumePanelPr
   const baseAmount =
     marketInfo?.balance?.baseAmount === undefined
       ? 'N/A'
-      : formatSatsToUnit(marketInfo?.balance?.baseAmount, lbtcUnit, baseAsset?.asset_id, network);
+      : //: formatSatsToUnit(marketInfo?.balance?.baseAmount, lbtcUnit, baseAsset?.asset_id, network);
+        fromSatoshiToUnitOrFractional(
+          marketInfo?.balance?.baseAmount,
+          baseAsset.precision,
+          isLbtcAssetId(baseAsset?.asset_id, network) ? lbtcUnit : baseAsset?.ticker
+        );
   const quoteAmount =
     marketInfo?.balance?.quoteAmount === undefined
       ? 'N/A'
-      : formatSatsToUnit(marketInfo?.balance?.quoteAmount, lbtcUnit, quoteAsset?.asset_id, network);
+      : fromSatoshiToUnitOrFractional(
+          marketInfo?.balance?.quoteAmount,
+          quoteAsset.precision,
+          isLbtcAssetId(quoteAsset?.asset_id, network) ? lbtcUnit : quoteAsset?.ticker
+        );
 
   return (
     <div className="panel panel__grey h-100">
@@ -51,13 +60,21 @@ export const VolumePanel = ({ baseAsset, quoteAsset, marketInfo }: VolumePanelPr
           <Col span={8} className="text-end">
             <span className="dm-mono dm-mono__x dm_mono__bold mx-2">{`${formatCompact(
               Number(
-                formatSatsToUnit(marketInfo.price?.basePrice ?? 0, lbtcUnit, baseAsset?.asset_id, network)
+                fromSatoshiToUnitOrFractional(
+                  marketInfo.price?.basePrice ?? 0,
+                  baseAsset.precision,
+                  isLbtcAssetId(baseAsset?.asset_id, network) ? lbtcUnit : baseAsset?.ticker
+                )
               )
             )} ${
               isLbtcAssetId(baseAsset?.asset_id, network) ? lbtcUnit : baseAsset?.ticker
             } for ${formatCompact(
               Number(
-                formatSatsToUnit(marketInfo.price?.quotePrice ?? 0, lbtcUnit, quoteAsset?.asset_id, network)
+                fromSatoshiToUnitOrFractional(
+                  marketInfo.price?.quotePrice ?? 0,
+                  quoteAsset.precision,
+                  isLbtcAssetId(quoteAsset?.asset_id, network) ? lbtcUnit : quoteAsset?.ticker
+                )
               )
             )} ${isLbtcAssetId(quoteAsset?.asset_id, network) ? lbtcUnit : quoteAsset?.ticker}`}</span>
           </Col>

--- a/src/features/operator/Market/MarketWithdraw/index.tsx
+++ b/src/features/operator/Market/MarketWithdraw/index.tsx
@@ -16,7 +16,7 @@ import { HOME_ROUTE, MARKET_OVERVIEW_ROUTE } from '../../../../routes/constants'
 import {
   formatFiatToSats,
   formatLbtcUnitToSats,
-  formatSatsToUnit,
+  fromSatoshiToUnitOrFractional,
   isLbtcAssetId,
   isLbtcTicker,
   LBTC_ASSET,
@@ -117,49 +117,45 @@ export const MarketWithdraw = (): JSX.Element => {
       notification.error({ message: err.message });
     }
   };
+  const baseUnitOrTickerFormatted = isLbtcTicker(selectedMarket?.baseAsset?.ticker)
+    ? lbtcUnit
+    : selectedMarket?.baseAsset?.ticker || 'N/A';
+  const quoteUnitOrTickerFormatted = isLbtcTicker(selectedMarket?.quoteAsset?.ticker)
+    ? lbtcUnit
+    : selectedMarket?.quoteAsset?.ticker || 'N/A';
 
   const baseAvailableAmountFormatted =
     marketBalance?.availableBalance?.baseAmount === undefined || !selectedMarket.baseAsset?.asset_id
       ? 'N/A'
-      : formatSatsToUnit(
+      : fromSatoshiToUnitOrFractional(
           marketBalance?.availableBalance?.baseAmount,
-          lbtcUnit,
-          selectedMarket.baseAsset?.asset_id,
-          network
+          selectedMarket?.baseAsset?.precision,
+          baseUnitOrTickerFormatted
         );
   const baseTotalAmountFormatted =
     marketBalance?.totalBalance?.baseAmount === undefined || !selectedMarket.baseAsset?.asset_id
       ? 'N/A'
-      : formatSatsToUnit(
+      : fromSatoshiToUnitOrFractional(
           marketBalance?.totalBalance?.baseAmount,
-          lbtcUnit,
-          selectedMarket.baseAsset?.asset_id,
-          network
+          selectedMarket?.baseAsset?.precision,
+          baseUnitOrTickerFormatted
         );
   const quoteAvailableAmountFormatted =
     marketBalance?.availableBalance?.baseAmount === undefined || !selectedMarket.quoteAsset?.asset_id
       ? 'N/A'
-      : formatSatsToUnit(
+      : fromSatoshiToUnitOrFractional(
           marketBalance?.availableBalance?.quoteAmount,
-          lbtcUnit,
-          selectedMarket.quoteAsset?.asset_id,
-          network
+          selectedMarket?.quoteAsset?.precision,
+          quoteUnitOrTickerFormatted
         );
   const quoteTotalAmountFormatted =
     marketBalance?.totalBalance?.baseAmount === undefined || !selectedMarket.quoteAsset?.asset_id
       ? 'N/A'
-      : formatSatsToUnit(
+      : fromSatoshiToUnitOrFractional(
           marketBalance?.totalBalance?.quoteAmount,
-          lbtcUnit,
-          selectedMarket.quoteAsset?.asset_id,
-          network
+          selectedMarket?.quoteAsset?.precision,
+          quoteUnitOrTickerFormatted
         );
-  const baseTickerFormatted = isLbtcTicker(selectedMarket?.baseAsset?.ticker)
-    ? lbtcUnit
-    : selectedMarket?.baseAsset?.ticker || 'N/A';
-  const quoteTickerFormatted = isLbtcTicker(selectedMarket?.quoteAsset?.ticker)
-    ? lbtcUnit
-    : selectedMarket?.quoteAsset?.ticker || 'N/A';
 
   return (
     <>
@@ -207,14 +203,14 @@ export const MarketWithdraw = (): JSX.Element => {
               <Row className="align-center">
                 <Col span={12}>
                   <CurrencyIcon currency={selectedMarket?.baseAsset?.ticker || ''} />
-                  <span className="dm-sans dm-sans__xx ml-2">{baseTickerFormatted}</span>
+                  <span className="dm-sans dm-sans__xx ml-2">{baseUnitOrTickerFormatted}</span>
                 </Col>
                 <Col span={12}>
                   <InputAmount
                     assetPrecision={selectedMarket?.baseAsset?.precision || 8}
                     formItemName="balanceBaseAmount"
                     hasError={!!withdrawMarketError}
-                    lbtcUnitOrTicker={baseTickerFormatted}
+                    lbtcUnitOrTicker={baseUnitOrTickerFormatted}
                     setInputValue={(value) => form.setFieldsValue({ balanceBaseAmount: value })}
                   />
                 </Col>
@@ -232,8 +228,8 @@ export const MarketWithdraw = (): JSX.Element => {
                         });
                       }
                     }}
-                  >{`${baseAvailableAmountFormatted} ${baseTickerFormatted}`}</Button>
-                  <span className="dm-mono dm-mono__bold d-block">{`Total balance: ${baseTotalAmountFormatted} ${baseTickerFormatted}`}</span>
+                  >{`${baseAvailableAmountFormatted} ${baseUnitOrTickerFormatted}`}</Button>
+                  <span className="dm-mono dm-mono__bold d-block">{`Total balance: ${baseTotalAmountFormatted} ${baseUnitOrTickerFormatted}`}</span>
                 </Col>
                 <Col className="dm-mono dm-mono__bold d-flex justify-end" span={8}>
                   0.00 USD
@@ -244,14 +240,14 @@ export const MarketWithdraw = (): JSX.Element => {
               <Row className="align-center">
                 <Col span={12}>
                   <CurrencyIcon currency={selectedMarket?.quoteAsset?.ticker || ''} />
-                  <span className="dm-sans dm-sans__xx ml-2">{quoteTickerFormatted}</span>
+                  <span className="dm-sans dm-sans__xx ml-2">{quoteUnitOrTickerFormatted}</span>
                 </Col>
                 <Col span={12}>
                   <InputAmount
                     assetPrecision={selectedMarket?.quoteAsset?.precision || 8}
                     formItemName="balanceQuoteAmount"
                     hasError={!!withdrawMarketError}
-                    lbtcUnitOrTicker={quoteTickerFormatted}
+                    lbtcUnitOrTicker={quoteUnitOrTickerFormatted}
                     setInputValue={(value) => form.setFieldsValue({ balanceQuoteAmount: value })}
                   />
                 </Col>
@@ -269,8 +265,8 @@ export const MarketWithdraw = (): JSX.Element => {
                         });
                       }
                     }}
-                  >{`${quoteAvailableAmountFormatted} ${quoteTickerFormatted}`}</Button>
-                  <span className="dm-mono dm-mono__bold d-block">{`Total balance: ${quoteTotalAmountFormatted} ${quoteTickerFormatted}`}</span>
+                  >{`${quoteAvailableAmountFormatted} ${quoteUnitOrTickerFormatted}`}</Button>
+                  <span className="dm-mono dm-mono__bold d-block">{`Total balance: ${quoteTotalAmountFormatted} ${quoteUnitOrTickerFormatted}`}</span>
                 </Col>
                 <Col className="dm-mono dm-mono__bold d-flex justify-end" span={8}>
                   0.00 USD

--- a/src/features/operator/TxsTable/AllRows.tsx
+++ b/src/features/operator/TxsTable/AllRows.tsx
@@ -6,7 +6,6 @@ import type { RootState } from '../../../app/store';
 import { useTypedSelector } from '../../../app/store';
 import type { Asset } from '../../../domain/asset';
 import type { LbtcUnit } from '../../../utils';
-import { getTickers } from '../../../utils';
 
 import type { DepositRow } from './DepositRows';
 import { getDepositData } from './DepositRows';
@@ -47,7 +46,8 @@ export const AllRows = ({
     if (aTime > bTime) return -1;
     return 0;
   });
-  const tickers = getTickers(marketInfo.market, savedAssets[network], lbtcUnit);
+  const baseAsset = savedAssets[network].find((a: Asset) => a.asset_id === marketInfo.market?.baseAsset);
+  const quoteAsset = savedAssets[network].find((a: Asset) => a.asset_id === marketInfo.market?.quoteAsset);
 
   const TableComponent = useMemo(
     () =>
@@ -58,21 +58,21 @@ export const AllRows = ({
           txId = '';
 
         if (mode === 'deposit') {
-          const data = getDepositData(row, lbtcUnit, marketInfo, network);
+          const data = getDepositData(row, lbtcUnit, marketInfo, baseAsset, quoteAsset);
           baseAmountFormatted = data.baseAmountFormatted;
           quoteAmountFormatted = data.quoteAmountFormatted;
           txId = data.txId;
         }
 
         if (mode === 'withdraw') {
-          const data = getWithdrawData(row, lbtcUnit, marketInfo, network);
+          const data = getWithdrawData(row, lbtcUnit, marketInfo, baseAsset, quoteAsset);
           baseAmountFormatted = data.baseAmountFormatted;
           quoteAmountFormatted = data.quoteAmountFormatted;
           txId = data.txId;
         }
 
         if (mode === 'trade') {
-          const data = getTradeData(row, lbtcUnit, network);
+          const data = getTradeData(row, lbtcUnit, network, savedAssets[network]);
           baseAmountFormatted = data.baseAmountFormatted;
           quoteAmountFormatted = data.quoteAmountFormatted;
           txId = data.txId;
@@ -81,7 +81,8 @@ export const AllRows = ({
           <TxRow
             key={`${txId}_${index}`}
             mode={mode}
-            tickers={tickers}
+            baseAsset={baseAsset}
+            quoteAsset={quoteAsset}
             baseAmountFormatted={baseAmountFormatted}
             quoteAmountFormatted={quoteAmountFormatted}
             row={row}
@@ -89,7 +90,7 @@ export const AllRows = ({
           />
         );
       }),
-    [all, lbtcUnit, marketInfo, network, numItemsToShow, tickers]
+    [all, baseAsset, lbtcUnit, marketInfo, network, numItemsToShow, quoteAsset, savedAssets]
   );
 
   return <>{TableComponent}</>;

--- a/src/features/operator/TxsTable/TradeRows.tsx
+++ b/src/features/operator/TxsTable/TradeRows.tsx
@@ -5,7 +5,7 @@ import type { RootState } from '../../../app/store';
 import { useTypedSelector } from '../../../app/store';
 import type { Asset } from '../../../domain/asset';
 import type { LbtcUnit } from '../../../utils';
-import { formatSatsToUnit, getTickers } from '../../../utils';
+import { fromSatoshiToUnitOrFractional } from '../../../utils';
 
 import type { TxData } from './TxRow';
 import { TxRow } from './TxRow';
@@ -20,22 +20,41 @@ interface TradeRowsProps {
 export const getTradeData = (
   row: TradeInfo.AsObject,
   lbtcUnit: LbtcUnit,
-  network: NetworkString
+  network: NetworkString,
+  assets: Asset[]
 ): { baseAmountFormatted: string; quoteAmountFormatted: string; txId: string } => {
+  const assetPropose = assets.find((a: Asset) => a.asset_id === row.swapInfo?.assetP);
+  const assetReceive = assets.find((a: Asset) => a.asset_id === row.swapInfo?.assetR);
   const proposedIsBase = row.marketWithFee?.market?.baseAsset === row.swapInfo?.assetP;
   const baseAmountFormatted = proposedIsBase
     ? row.swapInfo?.amountP
-      ? formatSatsToUnit(row.swapInfo?.amountP, lbtcUnit, row.swapInfo?.assetP, network)
+      ? fromSatoshiToUnitOrFractional(
+          row.swapInfo?.amountP,
+          assetPropose?.precision,
+          assetPropose?.unitOrTicker ?? ''
+        )
       : 'N/A'
     : row.swapInfo?.amountR
-    ? formatSatsToUnit(row.swapInfo?.amountR, lbtcUnit, row.swapInfo?.assetR, network)
+    ? fromSatoshiToUnitOrFractional(
+        row.swapInfo?.amountR,
+        assetReceive?.precision,
+        assetReceive?.unitOrTicker ?? ''
+      )
     : 'N/A';
   const quoteAmountFormatted = proposedIsBase
     ? row.swapInfo?.amountP
-      ? formatSatsToUnit(row.swapInfo?.amountR, lbtcUnit, row.swapInfo?.assetR, network)
+      ? fromSatoshiToUnitOrFractional(
+          row.swapInfo?.amountR,
+          assetReceive?.precision,
+          assetReceive?.unitOrTicker ?? ''
+        )
       : 'N/A'
     : row.swapInfo?.amountR
-    ? formatSatsToUnit(row.swapInfo?.amountP, lbtcUnit, row.swapInfo?.assetP, network)
+    ? fromSatoshiToUnitOrFractional(
+        row.swapInfo?.amountP,
+        assetPropose?.precision,
+        assetPropose?.unitOrTicker ?? ''
+      )
     : 'N/A';
   const txId = row.txUrl.substring(row.txUrl.lastIndexOf('/') + 1, row.txUrl.indexOf('#'));
   return { baseAmountFormatted, quoteAmountFormatted, txId };
@@ -43,16 +62,18 @@ export const getTradeData = (
 
 export const TradeRows = ({ trades, savedAssets, marketInfo, lbtcUnit }: TradeRowsProps): JSX.Element => {
   const { network } = useTypedSelector(({ settings }: RootState) => settings);
+  const baseAsset = savedAssets[network].find((a: Asset) => a.asset_id === marketInfo.market?.baseAsset);
+  const quoteAsset = savedAssets[network].find((a: Asset) => a.asset_id === marketInfo.market?.quoteAsset);
   return (
     <>
       {trades?.map((row, index) => {
-        const data = getTradeData(row, lbtcUnit, network);
-        const tickers = getTickers(marketInfo.market, savedAssets[network], lbtcUnit);
+        const data = getTradeData(row, lbtcUnit, network, savedAssets[network]);
         return (
           <TxRow
             key={`${data.txId}_${index}`}
             mode="trade"
-            tickers={tickers}
+            baseAsset={baseAsset}
+            quoteAsset={quoteAsset}
             baseAmountFormatted={data.baseAmountFormatted}
             quoteAmountFormatted={data.quoteAmountFormatted}
             row={row as TxData}

--- a/src/features/operator/TxsTable/TxRow.tsx
+++ b/src/features/operator/TxsTable/TxRow.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import type { TradeInfo, Withdrawal } from '../../../api-spec/generated/js/operator_pb';
 import { ReactComponent as depositIcon } from '../../../assets/images/deposit.svg';
 import { CurrencyIcon } from '../../../common/CurrencyIcon';
+import type { Asset } from '../../../domain/asset';
 import { timeAgo } from '../../../utils';
 import { useGetTransactionByIdQuery } from '../../liquid.api';
 
@@ -14,12 +15,8 @@ export type TxData = TradeInfo.AsObject & DepositRow & Withdrawal.AsObject;
 
 interface TxRowProps {
   mode: TableMode;
-  tickers: {
-    baseAssetTicker: string;
-    quoteAssetTicker: string;
-    baseAssetTickerFormatted: string;
-    quoteAssetTickerFormatted: string;
-  };
+  baseAsset?: Asset;
+  quoteAsset?: Asset;
   baseAmountFormatted: string;
   quoteAmountFormatted: string;
   row: TxData;
@@ -28,7 +25,8 @@ interface TxRowProps {
 
 export const TxRow = ({
   mode,
-  tickers,
+  baseAsset,
+  quoteAsset,
   baseAmountFormatted,
   quoteAmountFormatted,
   row,
@@ -44,11 +42,11 @@ export const TxRow = ({
   const hasBaseAmount = baseAmountFormatted !== 'N/A' && Number(baseAmountFormatted) !== 0;
   const hasQuoteAmount = quoteAmountFormatted !== 'N/A' && Number(quoteAmountFormatted) !== 0;
   if (hasBaseAmount && hasQuoteAmount) {
-    tickerStr = `${tickers.baseAssetTickerFormatted} - ${tickers.quoteAssetTickerFormatted}`;
+    tickerStr = `${baseAsset?.unitOrTicker} - ${quoteAsset?.unitOrTicker}`;
   } else if (hasBaseAmount) {
-    tickerStr = tickers.baseAssetTickerFormatted;
+    tickerStr = baseAsset?.unitOrTicker;
   } else if (hasQuoteAmount) {
-    tickerStr = tickers.quoteAssetTickerFormatted;
+    tickerStr = quoteAsset?.unitOrTicker;
   }
 
   return (
@@ -62,10 +60,10 @@ export const TxRow = ({
         {mode === 'trade' && (
           <td>
             <span className="market-icons-translate__small">
-              <CurrencyIcon className="base-icon" currency={tickers.baseAssetTicker} size={16} />
-              <CurrencyIcon className="quote-icon" currency={tickers.quoteAssetTicker} size={16} />
+              <CurrencyIcon className="base-icon" currency={baseAsset?.unitOrTicker ?? ''} size={16} />
+              <CurrencyIcon className="quote-icon" currency={quoteAsset?.unitOrTicker ?? ''} size={16} />
             </span>
-            {`Swap ${tickers.baseAssetTickerFormatted} for ${tickers.quoteAssetTickerFormatted}`}
+            {`Swap ${baseAsset?.unitOrTicker} for ${quoteAsset?.unitOrTicker}`}
           </td>
         )}
         {mode === 'withdraw' && (
@@ -103,8 +101,8 @@ export const TxRow = ({
           )}
         </td>
         <td>{baseAmountFormatted}</td>
-        <td>{`${baseAmountFormatted} ${tickers.baseAssetTickerFormatted}`}</td>
-        <td>{`${quoteAmountFormatted} ${tickers.quoteAssetTickerFormatted}`}</td>
+        <td>{`${baseAmountFormatted} ${baseAsset?.unitOrTicker}`}</td>
+        <td>{`${quoteAmountFormatted} ${quoteAsset?.unitOrTicker}`}</td>
         <td data-time={time}>{timeAgo(time)}</td>
         <td>
           <RightOutlined />

--- a/src/features/operator/TxsTable/WithdrawalRows.tsx
+++ b/src/features/operator/TxsTable/WithdrawalRows.tsx
@@ -6,7 +6,7 @@ import type { RootState } from '../../../app/store';
 import { useTypedSelector } from '../../../app/store';
 import type { Asset } from '../../../domain/asset';
 import type { LbtcUnit } from '../../../utils';
-import { formatSatsToUnit, getTickers } from '../../../utils';
+import { fromSatoshiToUnitOrFractional } from '../../../utils';
 
 import type { TxData } from './TxRow';
 import { TxRow } from './TxRow';
@@ -22,16 +22,25 @@ export const getWithdrawData = (
   row: Withdrawal.AsObject,
   lbtcUnit: LbtcUnit,
   marketInfo: MarketInfo.AsObject,
-  network: NetworkString
+  baseAsset?: Asset,
+  quoteAsset?: Asset
 ): { baseAmountFormatted: string; quoteAmountFormatted: string; txId: string } => {
   const baseAmountFormatted =
     row.balance?.baseAmount === undefined || !marketInfo.market?.baseAsset
       ? 'N/A'
-      : formatSatsToUnit(row.balance?.baseAmount, lbtcUnit, marketInfo.market?.baseAsset, network);
+      : fromSatoshiToUnitOrFractional(
+          row.balance?.baseAmount,
+          baseAsset?.precision,
+          baseAsset?.unitOrTicker ?? ''
+        );
   const quoteAmountFormatted =
     row.balance?.quoteAmount === undefined || !marketInfo.market?.quoteAsset
       ? 'N/A'
-      : formatSatsToUnit(row.balance?.quoteAmount, lbtcUnit, marketInfo.market?.quoteAsset, network);
+      : fromSatoshiToUnitOrFractional(
+          row.balance?.quoteAmount,
+          quoteAsset?.precision,
+          quoteAsset?.unitOrTicker ?? ''
+        );
   const txId = row.txId;
   return { baseAmountFormatted, quoteAmountFormatted, txId };
 };
@@ -43,16 +52,18 @@ export const WithdrawalRows = ({
   lbtcUnit,
 }: WithdrawalRowsProps): JSX.Element => {
   const { network } = useTypedSelector(({ settings }: RootState) => settings);
+  const baseAsset = savedAssets[network].find((a: Asset) => a.asset_id === marketInfo.market?.baseAsset);
+  const quoteAsset = savedAssets[network].find((a: Asset) => a.asset_id === marketInfo.market?.quoteAsset);
   return (
     <>
       {withdrawals?.map((row) => {
-        const data = getWithdrawData(row, lbtcUnit, marketInfo, network);
-        const tickers = getTickers(marketInfo.market, savedAssets[network], lbtcUnit);
+        const data = getWithdrawData(row, lbtcUnit, marketInfo, baseAsset, quoteAsset);
         return (
           <TxRow
             key={data.txId}
             mode="withdraw"
-            tickers={tickers}
+            baseAsset={baseAsset}
+            quoteAsset={quoteAsset}
             baseAmountFormatted={data.baseAmountFormatted}
             quoteAmountFormatted={data.quoteAmountFormatted}
             row={row as TxData}

--- a/src/utils/asset.ts
+++ b/src/utils/asset.ts
@@ -1,10 +1,8 @@
 import type { NetworkString } from 'ldk';
 
 import type { MarketInfo } from '../api-spec/generated/js/operator_pb';
-import type { Market } from '../api-spec/generated/js/types_pb';
 import type { Asset } from '../domain/asset';
 
-import type { LbtcUnit } from './constants';
 import { LBTC_ASSET, LBTC_TICKER, LCAD_ASSET, LCAD_TICKER, USDT_ASSET, USDT_TICKER } from './constants';
 import { filterUndef } from './snippets';
 
@@ -39,21 +37,4 @@ export const getAllAssetIdsFromMarkets = (marketsList: MarketInfo.AsObject[]): s
       )
     )
   );
-};
-
-export const getTickers = (
-  market: Market.AsObject = { baseAsset: '', quoteAsset: '' },
-  savedAssets: Asset[],
-  lbtcUnit: LbtcUnit
-): {
-  baseAssetTicker: string;
-  quoteAssetTicker: string;
-  baseAssetTickerFormatted: string;
-  quoteAssetTickerFormatted: string;
-} => {
-  const baseAssetTicker = assetIdToTicker(market?.baseAsset || '', savedAssets);
-  const quoteAssetTicker = assetIdToTicker(market?.quoteAsset || '', savedAssets);
-  const baseAssetTickerFormatted = isLbtcTicker(baseAssetTicker) ? lbtcUnit : baseAssetTicker;
-  const quoteAssetTickerFormatted = isLbtcTicker(quoteAssetTicker) ? lbtcUnit : quoteAssetTicker;
-  return { baseAssetTicker, quoteAssetTicker, baseAssetTickerFormatted, quoteAssetTickerFormatted };
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -42,18 +42,21 @@ export const USDT_ASSET: Record<NetworkString, Asset> = {
     name: 'Tether USD',
     precision: 8,
     ticker: USDT_TICKER,
+    unitOrTicker: USDT_TICKER,
   },
   testnet: {
     asset_id: 'f3d1ec678811398cd2ae277cbe3849c6f6dbd72c74bc542f7c4b11ff0e820958',
     name: 'Tether USD',
     precision: 8,
     ticker: USDT_TICKER,
+    unitOrTicker: USDT_TICKER,
   },
   regtest: {
     asset_id: 'ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2',
     name: 'Tether USD',
     precision: 8,
     ticker: USDT_TICKER,
+    unitOrTicker: USDT_TICKER,
   },
 };
 
@@ -63,18 +66,21 @@ export const LCAD_ASSET: Record<NetworkString, Asset> = {
     name: 'Liquid CAD',
     precision: 8,
     ticker: LCAD_TICKER,
+    unitOrTicker: LCAD_TICKER,
   },
   testnet: {
     asset_id: 'ac3e0ff248c5051ffd61e00155b7122e5ebc04fd397a0ecbdd4f4e4a56232926',
     name: 'Liquid CAD',
     precision: 8,
     ticker: LCAD_TICKER,
+    unitOrTicker: LCAD_TICKER,
   },
   regtest: {
     asset_id: '1ad48d8c8c6f86b05ffdba5938bacde697f74281ff19eb552815697ad5047f74',
     name: 'Liquid CAD',
     precision: 8,
     ticker: LCAD_TICKER,
+    unitOrTicker: LCAD_TICKER,
   },
 };
 


### PR DESCRIPTION
- Rename formatSatsToUnit to fromSatoshiToUnitOrFractional and take into account asset precision
- getAssetData returns Asset with unitOrTicker
- Add unitOrTicker to Asset
  - Used when we want to display either the asset ticker or LBTC unit
  - Used in fromSatoshiToUnitOrFractional() to determine if asset is LBTC or not 