### PR TITLE
Fix asset precision, refactoring

### DIFF
--- a/src/domain/asset.ts
+++ b/src/domain/asset.ts
@@ -1,5 +1,6 @@
 export type Asset = {
   ticker: string;
+  // Either LBTC unit or asset ticker
   formattedTicker?: string;
   asset_id: string;
   name: string;

--- a/src/domain/asset.ts
+++ b/src/domain/asset.ts
@@ -1,5 +1,6 @@
 export type Asset = {
   ticker: string;
+  formattedTicker?: string;
   asset_id: string;
   name: string;
   precision: number;

--- a/src/features/home/DashboardPanelLeft.tsx
+++ b/src/features/home/DashboardPanelLeft.tsx
@@ -5,11 +5,9 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import type { Market } from '../../api-spec/generated/js/types_pb';
-import type { RootState } from '../../app/store';
-import { useTypedSelector } from '../../app/store';
 import { CREATE_MARKET_ROUTE } from '../../routes/constants';
 import type { LbtcUnit } from '../../utils';
-import { formatSatsToUnit, LBTC_ASSET } from '../../utils';
+import { fromSatsToUnitOrFractional } from '../../utils';
 import { useListMarketsQuery, useTotalCollectedSwapFeesQuery } from '../operator/operator.api';
 
 const { Title } = Typography;
@@ -20,7 +18,6 @@ interface DashboardPanelLeftProps {
 
 export const DashboardPanelLeft = ({ lbtcUnit }: DashboardPanelLeftProps): JSX.Element => {
   const navigate = useNavigate();
-  const { network } = useTypedSelector(({ settings }: RootState) => settings);
   const { data: listMarkets } = useListMarketsQuery();
   const activeMarkets = listMarkets?.marketsList.filter((m) => m.tradable).length || 0;
   const pausedMarkets = (listMarkets?.marketsList.length ?? 0) - activeMarkets;
@@ -37,7 +34,7 @@ export const DashboardPanelLeft = ({ lbtcUnit }: DashboardPanelLeftProps): JSX.E
         <Col className="dm-mono dm-mono__xxxxxx" span={12}>
           {totalCollectedSwapFees === undefined
             ? 'N/A'
-            : formatSatsToUnit(totalCollectedSwapFees, lbtcUnit, LBTC_ASSET[network].asset_id, network)}
+            : fromSatsToUnitOrFractional(totalCollectedSwapFees, 8, true, lbtcUnit)}
         </Col>
         <Col className="total-earned-change" span={12}>
           <div>24h</div>

--- a/src/features/home/DashboardPanelRight.tsx
+++ b/src/features/home/DashboardPanelRight.tsx
@@ -3,12 +3,10 @@ import Icon from '@ant-design/icons';
 import { Button, Col, Row, Typography } from 'antd';
 import { useNavigate } from 'react-router-dom';
 
-import type { RootState } from '../../app/store';
-import { useTypedSelector } from '../../app/store';
 import { ReactComponent as depositIcon } from '../../assets/images/deposit-green.svg';
 import { FEE_DEPOSIT_ROUTE, FEE_WITHDRAW_ROUTE } from '../../routes/constants';
 import type { LbtcUnit } from '../../utils';
-import { formatSatsToUnit, LBTC_ASSET } from '../../utils';
+import { fromSatsToUnitOrFractional } from '../../utils';
 import { useGetFeeBalanceQuery } from '../operator/operator.api';
 
 const { Title } = Typography;
@@ -19,7 +17,6 @@ interface DashboardPanelRightProps {
 
 export const DashboardPanelRight = ({ lbtcUnit }: DashboardPanelRightProps): JSX.Element => {
   const navigate = useNavigate();
-  const { network } = useTypedSelector(({ settings }: RootState) => settings);
   const { data: feeBalance } = useGetFeeBalanceQuery();
 
   return (
@@ -31,7 +28,7 @@ export const DashboardPanelRight = ({ lbtcUnit }: DashboardPanelRightProps): JSX
         <Col className="dm-mono dm-mono__xxxxxx" span={24}>
           {feeBalance?.totalBalance === undefined
             ? 'N/A'
-            : formatSatsToUnit(feeBalance?.totalBalance, lbtcUnit, LBTC_ASSET[network].asset_id, network)}
+            : fromSatsToUnitOrFractional(feeBalance?.totalBalance, 8, true, lbtcUnit)}
         </Col>
       </Row>
       <Row gutter={{ xs: 8, sm: 12, md: 16 }}>

--- a/src/features/operator/Fee/FeeForm/index.tsx
+++ b/src/features/operator/Fee/FeeForm/index.tsx
@@ -12,8 +12,9 @@ import type { Asset } from '../../../../domain/asset';
 import {
   formatFiatToSats,
   formatLbtcUnitToSats,
-  formatSatsToUnit,
+  fromSatsToUnitOrFractional,
   isLbtcAssetId,
+  isLbtcTicker,
   sleep,
 } from '../../../../utils';
 import {
@@ -101,17 +102,17 @@ export const FeeForm = ({
   const resetAll = async () => {
     if (!marketInfo?.fee?.fixed) return;
     form.setFieldsValue({
-      feeAbsoluteBaseInput: formatSatsToUnit(
+      feeAbsoluteBaseInput: fromSatsToUnitOrFractional(
         marketInfo.fee.fixed.baseFee,
-        lbtcUnit,
-        baseAsset.asset_id,
-        network
+        baseAsset.precision,
+        isLbtcTicker(baseAsset.ticker),
+        lbtcUnit
       ),
-      feeAbsoluteQuoteInput: formatSatsToUnit(
+      feeAbsoluteQuoteInput: fromSatsToUnitOrFractional(
         marketInfo.fee.fixed.quoteFee,
-        lbtcUnit,
-        quoteAsset.asset_id,
-        network
+        quoteAsset.precision,
+        isLbtcTicker(quoteAsset.ticker),
+        lbtcUnit
       ),
       feeRelativeInput: String(marketInfo.fee.basisPoint / 100),
     });
@@ -123,17 +124,17 @@ export const FeeForm = ({
       form={form}
       name="fee_form"
       initialValues={{
-        feeAbsoluteBaseInput: formatSatsToUnit(
+        feeAbsoluteBaseInput: fromSatsToUnitOrFractional(
           Number(feeAbsoluteBase),
-          lbtcUnit,
-          baseAsset.asset_id,
-          network
+          baseAsset.precision,
+          isLbtcTicker(baseAsset.ticker),
+          lbtcUnit
         ),
-        feeAbsoluteQuoteInput: formatSatsToUnit(
+        feeAbsoluteQuoteInput: fromSatsToUnitOrFractional(
           Number(feeAbsoluteQuote),
-          lbtcUnit,
-          quoteAsset.asset_id,
-          network
+          quoteAsset.precision,
+          isLbtcTicker(quoteAsset.ticker),
+          lbtcUnit
         ),
         feeRelativeInput: Number(feeRelative) / 100,
       }}

--- a/src/features/operator/Fee/FeeWithdraw/index.tsx
+++ b/src/features/operator/Fee/FeeWithdraw/index.tsx
@@ -11,7 +11,7 @@ import { ReactComponent as chevronRight } from '../../../../assets/images/chevro
 import { CurrencyIcon } from '../../../../common/CurrencyIcon';
 import { InputAmount } from '../../../../common/InputAmount';
 import { HOME_ROUTE } from '../../../../routes/constants';
-import { formatLbtcUnitToSats, formatSatsToUnit, LBTC_ASSET, LBTC_TICKER } from '../../../../utils';
+import { formatLbtcUnitToSats, fromSatsToUnitOrFractional, LBTC_TICKER } from '../../../../utils';
 import { useGetFeeBalanceQuery, useWithdrawFeeMutation } from '../../operator.api';
 
 interface IFormInputs {
@@ -30,11 +30,11 @@ export const FeeWithdraw = (): JSX.Element => {
   const feeAvailableBalanceFormatted =
     feeBalance?.availableBalance === undefined
       ? 'N/A'
-      : formatSatsToUnit(feeBalance?.availableBalance, lbtcUnit, LBTC_ASSET[network].asset_id, network);
+      : fromSatsToUnitOrFractional(feeBalance?.availableBalance, 8, true, lbtcUnit);
   const feeTotalBalanceFormatted =
     feeBalance?.totalBalance === undefined
       ? 'N/A'
-      : formatSatsToUnit(feeBalance?.totalBalance, lbtcUnit, LBTC_ASSET[network].asset_id, network);
+      : fromSatsToUnitOrFractional(feeBalance?.totalBalance, 8, true, lbtcUnit);
 
   const onFinish = async () => {
     try {

--- a/src/features/operator/Market/MarketOverview/VolumePanel.tsx
+++ b/src/features/operator/Market/MarketOverview/VolumePanel.tsx
@@ -6,7 +6,7 @@ import { useTypedSelector } from '../../../../app/store';
 import { CurrencyIcon } from '../../../../common/CurrencyIcon';
 import { VolumeChart } from '../../../../common/VolumeChart';
 import type { Asset } from '../../../../domain/asset';
-import { formatCompact, formatSatsToUnit, isLbtcAssetId } from '../../../../utils';
+import { formatCompact, fromSatsToUnitOrFractional, isLbtcAssetId, isLbtcTicker } from '../../../../utils';
 
 interface VolumePanelProps {
   baseAsset: Asset;
@@ -22,11 +22,21 @@ export const VolumePanel = ({ baseAsset, quoteAsset, marketInfo }: VolumePanelPr
   const baseAmount =
     marketInfo?.balance?.baseAmount === undefined
       ? 'N/A'
-      : formatSatsToUnit(marketInfo?.balance?.baseAmount, lbtcUnit, baseAsset?.asset_id, network);
+      : fromSatsToUnitOrFractional(
+          marketInfo?.balance?.baseAmount,
+          baseAsset.precision,
+          isLbtcTicker(baseAsset.ticker),
+          lbtcUnit
+        );
   const quoteAmount =
     marketInfo?.balance?.quoteAmount === undefined
       ? 'N/A'
-      : formatSatsToUnit(marketInfo?.balance?.quoteAmount, lbtcUnit, quoteAsset?.asset_id, network);
+      : fromSatsToUnitOrFractional(
+          marketInfo?.balance?.quoteAmount,
+          quoteAsset.precision,
+          isLbtcTicker(quoteAsset.ticker),
+          lbtcUnit
+        );
 
   return (
     <div className="panel panel__grey h-100">
@@ -51,13 +61,23 @@ export const VolumePanel = ({ baseAsset, quoteAsset, marketInfo }: VolumePanelPr
           <Col span={8} className="text-end">
             <span className="dm-mono dm-mono__x dm_mono__bold mx-2">{`${formatCompact(
               Number(
-                formatSatsToUnit(marketInfo.price?.basePrice ?? 0, lbtcUnit, baseAsset?.asset_id, network)
+                fromSatsToUnitOrFractional(
+                  marketInfo.price?.basePrice ?? 0,
+                  baseAsset.precision,
+                  isLbtcTicker(baseAsset.ticker),
+                  lbtcUnit
+                )
               )
             )} ${
               isLbtcAssetId(baseAsset?.asset_id, network) ? lbtcUnit : baseAsset?.ticker
             } for ${formatCompact(
               Number(
-                formatSatsToUnit(marketInfo.price?.quotePrice ?? 0, lbtcUnit, quoteAsset?.asset_id, network)
+                fromSatsToUnitOrFractional(
+                  marketInfo.price?.quotePrice ?? 0,
+                  quoteAsset.precision,
+                  isLbtcTicker(quoteAsset.ticker),
+                  lbtcUnit
+                )
               )
             )} ${isLbtcAssetId(quoteAsset?.asset_id, network) ? lbtcUnit : quoteAsset?.ticker}`}</span>
           </Col>

--- a/src/features/operator/Market/MarketWithdraw/index.tsx
+++ b/src/features/operator/Market/MarketWithdraw/index.tsx
@@ -16,7 +16,7 @@ import { HOME_ROUTE, MARKET_OVERVIEW_ROUTE } from '../../../../routes/constants'
 import {
   formatFiatToSats,
   formatLbtcUnitToSats,
-  formatSatsToUnit,
+  fromSatsToUnitOrFractional,
   isLbtcAssetId,
   isLbtcTicker,
   LBTC_ASSET,
@@ -121,38 +121,38 @@ export const MarketWithdraw = (): JSX.Element => {
   const baseAvailableAmountFormatted =
     marketBalance?.availableBalance?.baseAmount === undefined || !selectedMarket.baseAsset?.asset_id
       ? 'N/A'
-      : formatSatsToUnit(
+      : fromSatsToUnitOrFractional(
           marketBalance?.availableBalance?.baseAmount,
-          lbtcUnit,
-          selectedMarket.baseAsset?.asset_id,
-          network
+          selectedMarket?.baseAsset?.precision,
+          isLbtcTicker(selectedMarket?.baseAsset?.ticker),
+          lbtcUnit
         );
   const baseTotalAmountFormatted =
     marketBalance?.totalBalance?.baseAmount === undefined || !selectedMarket.baseAsset?.asset_id
       ? 'N/A'
-      : formatSatsToUnit(
+      : fromSatsToUnitOrFractional(
           marketBalance?.totalBalance?.baseAmount,
-          lbtcUnit,
-          selectedMarket.baseAsset?.asset_id,
-          network
+          selectedMarket?.baseAsset?.precision,
+          isLbtcTicker(selectedMarket?.baseAsset?.ticker),
+          lbtcUnit
         );
   const quoteAvailableAmountFormatted =
     marketBalance?.availableBalance?.baseAmount === undefined || !selectedMarket.quoteAsset?.asset_id
       ? 'N/A'
-      : formatSatsToUnit(
+      : fromSatsToUnitOrFractional(
           marketBalance?.availableBalance?.quoteAmount,
-          lbtcUnit,
-          selectedMarket.quoteAsset?.asset_id,
-          network
+          selectedMarket?.quoteAsset?.precision,
+          isLbtcTicker(selectedMarket?.quoteAsset?.ticker),
+          lbtcUnit
         );
   const quoteTotalAmountFormatted =
     marketBalance?.totalBalance?.baseAmount === undefined || !selectedMarket.quoteAsset?.asset_id
       ? 'N/A'
-      : formatSatsToUnit(
+      : fromSatsToUnitOrFractional(
           marketBalance?.totalBalance?.quoteAmount,
-          lbtcUnit,
-          selectedMarket.quoteAsset?.asset_id,
-          network
+          selectedMarket?.quoteAsset?.precision,
+          isLbtcTicker(selectedMarket?.quoteAsset?.ticker),
+          lbtcUnit
         );
   const baseTickerFormatted = isLbtcTicker(selectedMarket?.baseAsset?.ticker)
     ? lbtcUnit

--- a/src/features/operator/TxsTable/TradeRows.tsx
+++ b/src/features/operator/TxsTable/TradeRows.tsx
@@ -1,58 +1,88 @@
 import type { NetworkString } from 'ldk';
 
-import type { TradeInfo, MarketInfo } from '../../../api-spec/generated/js/operator_pb';
+import type { TradeInfo } from '../../../api-spec/generated/js/operator_pb';
 import type { RootState } from '../../../app/store';
 import { useTypedSelector } from '../../../app/store';
 import type { Asset } from '../../../domain/asset';
 import type { LbtcUnit } from '../../../utils';
-import { formatSatsToUnit, getTickers } from '../../../utils';
+import { fromSatsToUnitOrFractional, isLbtcTicker } from '../../../utils';
 
 import type { TxData } from './TxRow';
 import { TxRow } from './TxRow';
 
 interface TradeRowsProps {
   trades?: TradeInfo.AsObject[];
-  savedAssets: Record<NetworkString, Asset[]>;
-  marketInfo: MarketInfo.AsObject;
+  assets: Asset[];
   lbtcUnit: LbtcUnit;
+  baseAsset?: Asset;
+  quoteAsset?: Asset;
 }
 
 export const getTradeData = (
   row: TradeInfo.AsObject,
   lbtcUnit: LbtcUnit,
-  network: NetworkString
+  network: NetworkString,
+  assets: Asset[]
 ): { baseAmountFormatted: string; quoteAmountFormatted: string; txId: string } => {
   const proposedIsBase = row.marketWithFee?.market?.baseAsset === row.swapInfo?.assetP;
+  const assetPropose = assets.find((a: Asset) => a.asset_id === row.swapInfo?.assetP);
+  const assetReceive = assets.find((a: Asset) => a.asset_id === row.swapInfo?.assetR);
   const baseAmountFormatted = proposedIsBase
     ? row.swapInfo?.amountP
-      ? formatSatsToUnit(row.swapInfo?.amountP, lbtcUnit, row.swapInfo?.assetP, network)
+      ? fromSatsToUnitOrFractional(
+          row.swapInfo?.amountP,
+          assetPropose?.precision,
+          isLbtcTicker(assetPropose?.ticker),
+          lbtcUnit
+        )
       : 'N/A'
     : row.swapInfo?.amountR
-    ? formatSatsToUnit(row.swapInfo?.amountR, lbtcUnit, row.swapInfo?.assetR, network)
+    ? fromSatsToUnitOrFractional(
+        row.swapInfo?.amountR,
+        assetReceive?.precision,
+        isLbtcTicker(assetReceive?.ticker),
+        lbtcUnit
+      )
     : 'N/A';
   const quoteAmountFormatted = proposedIsBase
     ? row.swapInfo?.amountP
-      ? formatSatsToUnit(row.swapInfo?.amountR, lbtcUnit, row.swapInfo?.assetR, network)
+      ? fromSatsToUnitOrFractional(
+          row.swapInfo?.amountR,
+          assetReceive?.precision,
+          isLbtcTicker(assetReceive?.ticker),
+          lbtcUnit
+        )
       : 'N/A'
     : row.swapInfo?.amountR
-    ? formatSatsToUnit(row.swapInfo?.amountP, lbtcUnit, row.swapInfo?.assetP, network)
+    ? fromSatsToUnitOrFractional(
+        row.swapInfo?.amountP,
+        assetPropose?.precision,
+        isLbtcTicker(assetPropose?.ticker),
+        lbtcUnit
+      )
     : 'N/A';
   const txId = row.txUrl.substring(row.txUrl.lastIndexOf('/') + 1, row.txUrl.indexOf('#'));
   return { baseAmountFormatted, quoteAmountFormatted, txId };
 };
 
-export const TradeRows = ({ trades, savedAssets, marketInfo, lbtcUnit }: TradeRowsProps): JSX.Element => {
+export const TradeRows = ({
+  trades,
+  lbtcUnit,
+  assets,
+  baseAsset,
+  quoteAsset,
+}: TradeRowsProps): JSX.Element => {
   const { network } = useTypedSelector(({ settings }: RootState) => settings);
   return (
     <>
       {trades?.map((row, index) => {
-        const data = getTradeData(row, lbtcUnit, network);
-        const tickers = getTickers(marketInfo.market, savedAssets[network], lbtcUnit);
+        const data = getTradeData(row, lbtcUnit, network, assets);
         return (
           <TxRow
             key={`${data.txId}_${index}`}
             mode="trade"
-            tickers={tickers}
+            baseAsset={baseAsset}
+            quoteAsset={quoteAsset}
             baseAmountFormatted={data.baseAmountFormatted}
             quoteAmountFormatted={data.quoteAmountFormatted}
             row={row as TxData}

--- a/src/features/operator/TxsTable/TxRow.tsx
+++ b/src/features/operator/TxsTable/TxRow.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import type { TradeInfo, Withdrawal } from '../../../api-spec/generated/js/operator_pb';
 import { ReactComponent as depositIcon } from '../../../assets/images/deposit.svg';
 import { CurrencyIcon } from '../../../common/CurrencyIcon';
+import type { Asset } from '../../../domain/asset';
 import { timeAgo } from '../../../utils';
 import { useGetTransactionByIdQuery } from '../../liquid.api';
 
@@ -14,25 +15,22 @@ export type TxData = TradeInfo.AsObject & DepositRow & Withdrawal.AsObject;
 
 interface TxRowProps {
   mode: TableMode;
-  tickers: {
-    baseAssetTicker: string;
-    quoteAssetTicker: string;
-    baseAssetTickerFormatted: string;
-    quoteAssetTickerFormatted: string;
-  };
   baseAmountFormatted: string;
   quoteAmountFormatted: string;
   row: TxData;
   txId: string;
+  baseAsset?: Asset;
+  quoteAsset?: Asset;
 }
 
 export const TxRow = ({
   mode,
-  tickers,
   baseAmountFormatted,
   quoteAmountFormatted,
   row,
   txId,
+  baseAsset,
+  quoteAsset,
 }: TxRowProps): JSX.Element => {
   const { data: tx, refetch: refetchTx } = useGetTransactionByIdQuery(txId, { skip: !txId });
   if (!tx?.status?.confirmed) {
@@ -44,11 +42,11 @@ export const TxRow = ({
   const hasBaseAmount = baseAmountFormatted !== 'N/A' && Number(baseAmountFormatted) !== 0;
   const hasQuoteAmount = quoteAmountFormatted !== 'N/A' && Number(quoteAmountFormatted) !== 0;
   if (hasBaseAmount && hasQuoteAmount) {
-    tickerStr = `${tickers.baseAssetTickerFormatted} - ${tickers.quoteAssetTickerFormatted}`;
+    tickerStr = `${baseAsset?.ticker} - ${quoteAsset?.ticker}`;
   } else if (hasBaseAmount) {
-    tickerStr = tickers.baseAssetTickerFormatted;
+    tickerStr = baseAsset?.ticker;
   } else if (hasQuoteAmount) {
-    tickerStr = tickers.quoteAssetTickerFormatted;
+    tickerStr = quoteAsset?.ticker;
   }
 
   return (
@@ -62,10 +60,10 @@ export const TxRow = ({
         {mode === 'trade' && (
           <td>
             <span className="market-icons-translate__small">
-              <CurrencyIcon className="base-icon" currency={tickers.baseAssetTicker} size={16} />
-              <CurrencyIcon className="quote-icon" currency={tickers.quoteAssetTicker} size={16} />
+              <CurrencyIcon className="base-icon" currency={baseAsset?.ticker ?? ''} size={16} />
+              <CurrencyIcon className="quote-icon" currency={quoteAsset?.ticker ?? ''} size={16} />
             </span>
-            {`Swap ${tickers.baseAssetTickerFormatted} for ${tickers.quoteAssetTickerFormatted}`}
+            {`Swap ${baseAsset?.ticker} for ${quoteAsset?.ticker}`}
           </td>
         )}
         {mode === 'withdraw' && (
@@ -103,8 +101,8 @@ export const TxRow = ({
           )}
         </td>
         <td>{baseAmountFormatted}</td>
-        <td>{`${baseAmountFormatted} ${tickers.baseAssetTickerFormatted}`}</td>
-        <td>{`${quoteAmountFormatted} ${tickers.quoteAssetTickerFormatted}`}</td>
+        <td>{`${baseAmountFormatted} ${baseAsset?.formattedTicker}`}</td>
+        <td>{`${quoteAmountFormatted} ${quoteAsset?.formattedTicker}`}</td>
         <td data-time={time}>{timeAgo(time)}</td>
         <td>
           <RightOutlined />

--- a/src/features/operator/TxsTable/WithdrawalRows.tsx
+++ b/src/features/operator/TxsTable/WithdrawalRows.tsx
@@ -6,57 +6,71 @@ import type { RootState } from '../../../app/store';
 import { useTypedSelector } from '../../../app/store';
 import type { Asset } from '../../../domain/asset';
 import type { LbtcUnit } from '../../../utils';
-import { formatSatsToUnit, getTickers } from '../../../utils';
+import { fromSatsToUnitOrFractional, isLbtcTicker } from '../../../utils';
 
 import type { TxData } from './TxRow';
 import { TxRow } from './TxRow';
 
 interface WithdrawalRowsProps {
   marketInfo: MarketInfo.AsObject;
-  savedAssets: Record<NetworkString, Asset[]>;
   withdrawals?: Withdrawal.AsObject[];
   lbtcUnit: LbtcUnit;
+  baseAsset?: Asset;
+  quoteAsset?: Asset;
 }
 
 export const getWithdrawData = (
   row: Withdrawal.AsObject,
   lbtcUnit: LbtcUnit,
   marketInfo: MarketInfo.AsObject,
-  network: NetworkString
+  network: NetworkString,
+  baseAsset?: Asset,
+  quoteAsset?: Asset
 ): { baseAmountFormatted: string; quoteAmountFormatted: string; txId: string } => {
   const baseAmountFormatted =
     row.balance?.baseAmount === undefined || !marketInfo.market?.baseAsset
       ? 'N/A'
-      : formatSatsToUnit(row.balance?.baseAmount, lbtcUnit, marketInfo.market?.baseAsset, network);
+      : fromSatsToUnitOrFractional(
+          row.balance?.baseAmount,
+          baseAsset?.precision,
+          isLbtcTicker(baseAsset?.ticker),
+          lbtcUnit
+        );
   const quoteAmountFormatted =
     row.balance?.quoteAmount === undefined || !marketInfo.market?.quoteAsset
       ? 'N/A'
-      : formatSatsToUnit(row.balance?.quoteAmount, lbtcUnit, marketInfo.market?.quoteAsset, network);
+      : fromSatsToUnitOrFractional(
+          row.balance?.quoteAmount,
+          quoteAsset?.precision,
+          isLbtcTicker(quoteAsset?.ticker),
+          lbtcUnit
+        );
   const txId = row.txId;
   return { baseAmountFormatted, quoteAmountFormatted, txId };
 };
 
 export const WithdrawalRows = ({
   withdrawals,
-  savedAssets,
   marketInfo,
   lbtcUnit,
+  baseAsset,
+  quoteAsset,
 }: WithdrawalRowsProps): JSX.Element => {
   const { network } = useTypedSelector(({ settings }: RootState) => settings);
   return (
     <>
       {withdrawals?.map((row) => {
         const data = getWithdrawData(row, lbtcUnit, marketInfo, network);
-        const tickers = getTickers(marketInfo.market, savedAssets[network], lbtcUnit);
         return (
           <TxRow
             key={data.txId}
             mode="withdraw"
-            tickers={tickers}
             baseAmountFormatted={data.baseAmountFormatted}
             quoteAmountFormatted={data.quoteAmountFormatted}
             row={row as TxData}
             txId={data.txId}
+            baseAsset={baseAsset}
+            quoteAsset={quoteAsset}
           />
         );
       })}

--- a/src/features/operator/TxsTable/index.tsx
+++ b/src/features/operator/TxsTable/index.tsx
@@ -139,7 +139,7 @@ export const TxsTable = ({ marketInfo }: TxsTableProps): JSX.Element => {
     explorerLiquidUI,
     network,
   } = useTypedSelector(({ settings }) => settings);
-  // Get asset data from asset id, including formattedTicker
+  // Get asset data from registry, including formattedTicker
   const baseAsset = getAssetDataFromRegistry(
     marketInfo?.market?.baseAsset ?? '',
     savedAssets[network],

--- a/src/utils/asset.ts
+++ b/src/utils/asset.ts
@@ -1,7 +1,6 @@
 import type { NetworkString } from 'ldk';
 
 import type { MarketInfo } from '../api-spec/generated/js/operator_pb';
-import type { Market } from '../api-spec/generated/js/types_pb';
 import type { Asset } from '../domain/asset';
 
 import type { LbtcUnit } from './constants';
@@ -41,19 +40,25 @@ export const getAllAssetIdsFromMarkets = (marketsList: MarketInfo.AsObject[]): s
   );
 };
 
-export const getTickers = (
-  market: Market.AsObject = { baseAsset: '', quoteAsset: '' },
-  savedAssets: Asset[],
+/**
+ * Get asset data from asset id, including formattedTicker
+ * @param assetId
+ * @param assets
+ * @param lbtcUnit
+ */
+export const getAssetDataFromRegistry = (
+  assetId: string,
+  assets: Asset[],
   lbtcUnit: LbtcUnit
-): {
-  baseAssetTicker: string;
-  quoteAssetTicker: string;
-  baseAssetTickerFormatted: string;
-  quoteAssetTickerFormatted: string;
-} => {
-  const baseAssetTicker = assetIdToTicker(market?.baseAsset || '', savedAssets);
-  const quoteAssetTicker = assetIdToTicker(market?.quoteAsset || '', savedAssets);
-  const baseAssetTickerFormatted = isLbtcTicker(baseAssetTicker) ? lbtcUnit : baseAssetTicker;
-  const quoteAssetTickerFormatted = isLbtcTicker(quoteAssetTicker) ? lbtcUnit : quoteAssetTicker;
-  return { baseAssetTicker, quoteAssetTicker, baseAssetTickerFormatted, quoteAssetTickerFormatted };
+): Asset | undefined => {
+  const asset = assets.find((a: Asset) => a.asset_id === assetId);
+  if (!asset) {
+    return undefined;
+  } else {
+    // LBTC unit or asset ticker
+    const formattedTicker = isLbtcTicker(asset?.ticker)
+      ? lbtcUnit
+      : asset?.ticker ?? assetId.substring(0, 4).toUpperCase();
+    return Object.assign({}, asset, { formattedTicker });
+  }
 };

--- a/src/utils/unitConvert.ts
+++ b/src/utils/unitConvert.ts
@@ -1,9 +1,7 @@
 import Big from 'big.js';
-import type { NetworkString } from 'ldk';
 
-import { isLbtcAssetId } from './asset';
 import type { LbtcUnit } from './constants';
-import { LBTC_UNITS } from './constants';
+import { defaultPrecision, LBTC_UNITS } from './constants';
 import { includes } from './snippets';
 
 const rxLeadingZeros = /^[\s0]{2,}/;
@@ -22,35 +20,24 @@ const removeInsignificant = (str: string) => {
   return str;
 };
 
-export function formatSatsToUnit(
+/**
+ * Takes sats and returns LBTC formatted to favorite unit or asset formatted to fractional value solely based on precision
+ * @param sats
+ * @param precision
+ * @param isLbtc
+ * @param lbtcUnit
+ */
+export function fromSatsToUnitOrFractional(
   sats: number,
-  unit: LbtcUnit,
-  asset: string,
-  network: NetworkString
+  precision = defaultPrecision,
+  isLbtc: boolean,
+  lbtcUnit?: LbtcUnit
 ): string {
   try {
-    const val = new Big(sats);
-    const exp = val.e;
-    // If asset is not bitcoin format with precision 8
-    if (!isLbtcAssetId(asset, network)) {
-      val.e = exp - 8;
-      return removeInsignificant(val.toFixed(8));
-    }
-    switch (unit) {
-      case 'L-BTC':
-        val.e = exp - 8;
-        return removeInsignificant(val.toFixed(8));
-      case 'L-mBTC':
-        val.e = exp - 5;
-        return removeInsignificant(val.toFixed(5));
-      case 'L-bits':
-        val.e = exp - 2;
-        return removeInsignificant(val.toFixed(2));
-      case 'L-sats':
-        return removeInsignificant(val.toFixed(0));
-      default:
-        return removeInsignificant(val.toFixed(0));
-    }
+    const unit = isLbtc ? lbtcUnit : undefined;
+    return new Big(sats)
+      .div(new Big(10).pow(new Big(precision).minus(unitToExponent(unit)).toNumber()))
+      .toString();
   } catch (err) {
     console.error(err);
     return 'N/A';
@@ -127,5 +114,21 @@ export function lbtcUnitOrTickerToFractionalDigits(unitOrTicker: string, precisi
       return 0;
     default:
       return 8;
+  }
+}
+
+export function unitToExponent(unit?: LbtcUnit): number {
+  // Non-Lbtc asset returns 0
+  switch (unit) {
+    case 'L-BTC':
+      return 0;
+    case 'L-mBTC':
+      return 3;
+    case 'L-bits':
+      return 6;
+    case 'L-sats':
+      return 8;
+    default:
+      return 0;
   }
 }


### PR DESCRIPTION
- Rename `formatSatsToUnit` to `fromSatsToUnitOrFractional` and take into account asset precision
- `getAssetDataFromRegistry` returns Asset with a new `formattedTicker` property (either LBTC unit or ticker)
  - We don't include `formattedTicker` in store to avoid complexity keeping the prop in sync when changing unit 
  - `formattedTicker` is used when we want to display either the asset ticker or LBTC unit
  - Used in `src/features/operator/TxsTable/index.tsx` to compute `baseAsset` and `quoteAsset`, passing them down to components and used by `fromSatsToUnitOrFractional`

It closes #292 

Please review @tiero 