### PR TITLE
Volume chart

### DIFF
--- a/src/assets/styles/button.less
+++ b/src/assets/styles/button.less
@@ -95,6 +95,12 @@ a.ant-btn {
 
 // Radio buttons
 .ant-radio-group {
+  &.radio-green {
+    .ant-radio-button-wrapper {
+      background: @btn-default-bg !important;
+      color: @primary-color;
+    }
+  }
   .ant-radio-button-wrapper {
     height: 38px;
     font-weight: bold;
@@ -111,6 +117,9 @@ a.ant-btn {
     }
     &:hover, &:focus, &:checked {
       box-shadow: 0 0 0 1px @primary-color inset !important;
+    }
+    &:focus-within {
+      box-shadow: none;
     }
     &.ant-radio-button-wrapper-checked {
       box-shadow: 0 0 0 1px @primary-color inset !important;

--- a/src/common/VolumeChart/index.tsx
+++ b/src/common/VolumeChart/index.tsx
@@ -1,80 +1,38 @@
 import { Col, Row } from 'antd';
 import dayjs from 'dayjs';
-import { BarChart, XAxis, Tooltip, Bar, YAxis, ResponsiveContainer } from 'recharts';
+import { useMemo } from 'react';
+import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
-const data = [
-  {
-    time: '2021-01-09',
-    value: 4000,
-  },
-  {
-    time: '2021-02-03',
-    value: 3000,
-  },
-  {
-    time: '2021-02-16',
-    value: 2000,
-  },
-  {
-    time: '2021-03-09',
-    value: 2780,
-  },
-  {
-    time: '2021-05-21',
-    value: 1890,
-  },
-  {
-    time: '2021-05-01',
-    value: 2390,
-  },
-  {
-    time: '2021-05-23',
-    value: 234,
-  },
-  {
-    time: '2021-05-27',
-    value: 567,
-  },
-  {
-    time: '2021-06-03',
-    value: 1000,
-  },
-  {
-    time: '2021-06-12',
-    value: 1267,
-  },
-  {
-    time: '2021-06-23',
-    value: 2009,
-  },
-  {
-    time: '2021-06-24',
-    value: 2089,
-  },
-  {
-    time: '2021-06-28',
-    value: 3001,
-  },
-  {
-    time: '2021-07-01',
-    value: 3589,
-  },
-  {
-    time: '2021-07-06',
-    value: 3678,
-  },
-  {
-    time: '2021-07-14',
-    value: 3890,
-  },
-];
+import type { MarketReport } from '../../api-spec/generated/js/operator_pb';
+import { TimeFrame } from '../../api-spec/generated/js/operator_pb';
 
 interface VolumeChartProps {
   topLeft: JSX.Element;
   topRight: JSX.Element;
+  marketReport?: MarketReport.AsObject;
+  marketReportTimeFrame: TimeFrame;
 }
 
-export const VolumeChart = ({ topLeft, topRight }: VolumeChartProps): JSX.Element => {
+export const VolumeChart = ({
+  topLeft,
+  topRight,
+  marketReport,
+  marketReportTimeFrame,
+}: VolumeChartProps): JSX.Element => {
+  // Prepare data starting from last element
+  const data = useMemo(() => {
+    // TODO: Convert baseVolume to LBTC unit or fractional
+    // Wait for https://github.com/tdex-network/tdex-dashboard/pull/296
+    return marketReport?.groupedVolumeList.reduceRight(
+      (acc, curr) => acc.concat({ time: curr.startDate, value: curr.baseVolume }),
+      [] as { time: string; value: number }[]
+    );
+  }, [marketReport?.groupedVolumeList]);
+
+  // Calculate yAxis width
+  const yAxis = document.getElementsByClassName('recharts-cartesian-axis recharts-yAxis')[0];
+  const yAxisWidth = (yAxis as SVGGraphicsElement)?.getBBox().width;
+
   return (
     <>
       <Row>
@@ -82,17 +40,23 @@ export const VolumeChart = ({ topLeft, topRight }: VolumeChartProps): JSX.Elemen
         <Col span={20}>{topRight}</Col>
       </Row>
       <ResponsiveContainer width="100%" height={265}>
-        <BarChart width={730} height={250} data={data} margin={{ top: 5, right: 5, bottom: -12, left: -12 }}>
+        <BarChart width={730} height={250} data={data} margin={{ top: 5, bottom: -12 }}>
           <XAxis
             dataKey="time"
             axisLine={false}
             tickLine={false}
-            tickFormatter={(time) => dayjs(time).format('DD')}
-            minTickGap={1}
+            tickFormatter={(time) => {
+              if (marketReportTimeFrame === TimeFrame.HOUR) {
+                return dayjs(time).format('HH');
+              } else {
+                return dayjs(time).format('DD/MM');
+              }
+            }}
+            minTickGap={10}
             tickMargin={1}
             tickSize={1}
           />
-          <YAxis />
+          <YAxis width={yAxisWidth} />
           <Tooltip />
           <Bar dataKey="value" fill="#44a13c" />
         </BarChart>

--- a/src/common/VolumeChart/index.tsx
+++ b/src/common/VolumeChart/index.tsx
@@ -4,20 +4,20 @@ import { useMemo } from 'react';
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
 import type { MarketReport } from '../../api-spec/generated/js/operator_pb';
-import { TimeFrame } from '../../api-spec/generated/js/operator_pb';
+import { PredefinedPeriod } from '../../api-spec/generated/js/operator_pb';
 
 interface VolumeChartProps {
   topLeft: JSX.Element;
   topRight: JSX.Element;
   marketReport?: MarketReport.AsObject;
-  marketReportTimeFrame: TimeFrame;
+  marketReportPredefinedPeriod: PredefinedPeriod;
 }
 
 export const VolumeChart = ({
   topLeft,
   topRight,
   marketReport,
-  marketReportTimeFrame,
+  marketReportPredefinedPeriod,
 }: VolumeChartProps): JSX.Element => {
   // Prepare data starting from last element
   const data = useMemo(() => {
@@ -46,8 +46,11 @@ export const VolumeChart = ({
             axisLine={false}
             tickLine={false}
             tickFormatter={(time) => {
-              if (marketReportTimeFrame === TimeFrame.HOUR) {
-                return dayjs(time).format('HH');
+              if (
+                marketReportPredefinedPeriod === PredefinedPeriod.LAST_DAY ||
+                marketReportPredefinedPeriod === PredefinedPeriod.LAST_WEEK
+              ) {
+                return `${dayjs(time).format('HH')}h`;
               } else {
                 return dayjs(time).format('DD/MM');
               }

--- a/src/features/operator/Market/MarketOverview/VolumePanel.tsx
+++ b/src/features/operator/Market/MarketOverview/VolumePanel.tsx
@@ -17,7 +17,6 @@ interface VolumePanelProps {
   marketReport?: MarketReport.AsObject;
   setMarketReportPredefinedPeriod: Dispatch<SetStateAction<PredefinedPeriod>>;
   setMarketReportTimeFrame: Dispatch<SetStateAction<TimeFrame>>;
-  marketReportTimeFrame: TimeFrame;
   marketReportPredefinedPeriod: PredefinedPeriod;
 }
 
@@ -30,7 +29,6 @@ export const VolumePanel = ({
   marketReport,
   setMarketReportPredefinedPeriod,
   setMarketReportTimeFrame,
-  marketReportTimeFrame,
   marketReportPredefinedPeriod,
 }: VolumePanelProps): JSX.Element => {
   const { lbtcUnit, network } = useTypedSelector(({ settings }) => settings);
@@ -160,7 +158,7 @@ export const VolumePanel = ({
           </div>
         }
         marketReport={marketReport}
-        marketReportTimeFrame={marketReportTimeFrame}
+        marketReportPredefinedPeriod={marketReportPredefinedPeriod}
       />
     </div>
   );

--- a/src/features/operator/Market/MarketOverview/VolumePanel.tsx
+++ b/src/features/operator/Market/MarketOverview/VolumePanel.tsx
@@ -1,7 +1,9 @@
-import { Button, Col, Row, Typography } from 'antd';
+import { Col, Row, Typography, Radio } from 'antd';
+import type { Dispatch, SetStateAction } from 'react';
 import React from 'react';
 
-import type { MarketInfo } from '../../../../api-spec/generated/js/operator_pb';
+import type { MarketInfo, MarketReport } from '../../../../api-spec/generated/js/operator_pb';
+import { PredefinedPeriod, TimeFrame } from '../../../../api-spec/generated/js/operator_pb';
 import { useTypedSelector } from '../../../../app/store';
 import { CurrencyIcon } from '../../../../common/CurrencyIcon';
 import { VolumeChart } from '../../../../common/VolumeChart';
@@ -12,11 +14,25 @@ interface VolumePanelProps {
   baseAsset: Asset;
   quoteAsset: Asset;
   marketInfo?: MarketInfo.AsObject;
+  marketReport?: MarketReport.AsObject;
+  setMarketReportPredefinedPeriod: Dispatch<SetStateAction<PredefinedPeriod>>;
+  setMarketReportTimeFrame: Dispatch<SetStateAction<TimeFrame>>;
+  marketReportTimeFrame: TimeFrame;
+  marketReportPredefinedPeriod: PredefinedPeriod;
 }
 
 const { Title } = Typography;
 
-export const VolumePanel = ({ baseAsset, quoteAsset, marketInfo }: VolumePanelProps): JSX.Element => {
+export const VolumePanel = ({
+  baseAsset,
+  quoteAsset,
+  marketInfo,
+  marketReport,
+  setMarketReportPredefinedPeriod,
+  setMarketReportTimeFrame,
+  marketReportTimeFrame,
+  marketReportPredefinedPeriod,
+}: VolumePanelProps): JSX.Element => {
   const { lbtcUnit, network } = useTypedSelector(({ settings }) => settings);
 
   const baseAmount =
@@ -66,23 +82,85 @@ export const VolumePanel = ({ baseAsset, quoteAsset, marketInfo }: VolumePanelPr
       <VolumeChart
         topLeft={
           <div className="mb-4">
-            <Title className="dm-sans dm-sans__x dm-sans__bold dm-sans__grey ml-2 d-inline" level={3}>
+            <Title className="dm-sans dm-sans__x dm-sans__bold dm-sans__grey d-inline" level={3}>
               Volume
             </Title>
+            {/*TODO: Convert to fav currency https://github.com/tdex-network/tdex-dashboard/pull/267*/}
             <span className="dm-sans dm-sans__xx ml-2">$1.22b</span>
           </div>
         }
         topRight={
           <div className="text-end">
-            <Button className="mr-2">1D</Button>
-            <Button className="mr-2">7D</Button>
-            <Button className="mr-2">1M</Button>
-            <Button className="mr-2">3M</Button>
-            <Button className="mr-2">1Y</Button>
-            <Button className="mr-2">YTD</Button>
-            <Button>ALL</Button>
+            <Radio.Group className="radio-green" defaultValue={marketReportPredefinedPeriod}>
+              <Radio.Button
+                value={PredefinedPeriod.LAST_DAY}
+                onClick={() => {
+                  setMarketReportPredefinedPeriod(PredefinedPeriod.LAST_DAY);
+                  setMarketReportTimeFrame(TimeFrame.HOUR);
+                }}
+              >
+                1D
+              </Radio.Button>
+              <Radio.Button
+                value={PredefinedPeriod.LAST_WEEK}
+                onClick={() => {
+                  setMarketReportPredefinedPeriod(PredefinedPeriod.LAST_WEEK);
+                  setMarketReportTimeFrame(TimeFrame.FOUR_HOURS);
+                }}
+              >
+                7D
+              </Radio.Button>
+              <Radio.Button
+                value={PredefinedPeriod.LAST_MONTH}
+                onClick={() => {
+                  setMarketReportPredefinedPeriod(PredefinedPeriod.LAST_MONTH);
+                  setMarketReportTimeFrame(TimeFrame.DAY);
+                }}
+              >
+                1M
+              </Radio.Button>
+              <Radio.Button
+                value={PredefinedPeriod.LAST_THREE_MONTHS}
+                onClick={() => {
+                  setMarketReportPredefinedPeriod(PredefinedPeriod.LAST_THREE_MONTHS);
+                  setMarketReportTimeFrame(TimeFrame.DAY);
+                }}
+              >
+                3M
+              </Radio.Button>
+              <Radio.Button
+                value={''}
+                onClick={() => {
+                  // TODO: https://github.com/tdex-network/tdex-daemon/issues/569
+                  //setMarketReportPredefinedPeriod(PredefinedPeriod.LAST_YEAR);
+                  //setMarketReportTimeFrame(TimeFrame.WEEK);
+                }}
+              >
+                1Y
+              </Radio.Button>
+              <Radio.Button
+                value={PredefinedPeriod.YEAR_TO_DATE}
+                onClick={() => {
+                  setMarketReportPredefinedPeriod(PredefinedPeriod.YEAR_TO_DATE);
+                  setMarketReportTimeFrame(TimeFrame.WEEK);
+                }}
+              >
+                YTD
+              </Radio.Button>
+              <Radio.Button
+                value={PredefinedPeriod.ALL}
+                onClick={() => {
+                  setMarketReportPredefinedPeriod(PredefinedPeriod.ALL);
+                  setMarketReportTimeFrame(TimeFrame.WEEK);
+                }}
+              >
+                ALL
+              </Radio.Button>
+            </Radio.Group>
           </div>
         }
+        marketReport={marketReport}
+        marketReportTimeFrame={marketReportTimeFrame}
       />
     </div>
   );

--- a/src/features/operator/Market/MarketOverview/index.tsx
+++ b/src/features/operator/Market/MarketOverview/index.tsx
@@ -3,6 +3,7 @@ import { Breadcrumb, Button, Typography, Row, Col, Space, Skeleton } from 'antd'
 import React, { useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
+import { PredefinedPeriod, TimeFrame } from '../../../../api-spec/generated/js/operator_pb';
 import { useTypedSelector } from '../../../../app/store';
 import { ReactComponent as chevronRight } from '../../../../assets/images/chevron-right.svg';
 import { ReactComponent as depositIcon } from '../../../../assets/images/deposit-green.svg';
@@ -11,7 +12,7 @@ import type { Asset } from '../../../../domain/asset';
 import { HOME_ROUTE, MARKET_DEPOSIT_ROUTE, MARKET_WITHDRAW_ROUTE } from '../../../../routes/constants';
 import { FeeForm } from '../../Fee/FeeForm';
 import { TxsTable } from '../../TxsTable';
-import { useGetMarketBalanceQuery, useGetMarketInfoQuery } from '../../operator.api';
+import { useGetMarketBalanceQuery, useGetMarketInfoQuery, useGetMarketReportQuery } from '../../operator.api';
 import { MarketSettings } from '../MarketSettings';
 
 import { AssetInfoModal } from './AssetInfoModal';
@@ -42,6 +43,20 @@ export const MarketOverview = (): JSX.Element => {
       pollingInterval: isBalanceUpdating ? 2000 : 0,
     }
   );
+
+  // Market report
+  const [marketReportPredefinedPeriod, setMarketReportPredefinedPeriod] = useState<PredefinedPeriod>(
+    PredefinedPeriod.LAST_MONTH
+  );
+  const [marketReportTimeFrame, setMarketReportTimeFrame] = useState<TimeFrame>(TimeFrame.DAY);
+  const { data: marketReport } = useGetMarketReportQuery({
+    market: {
+      baseAsset: state.baseAsset?.asset_id,
+      quoteAsset: state.quoteAsset?.asset_id,
+    },
+    timeRange: { predefinedPeriod: marketReportPredefinedPeriod },
+    timeFrame: marketReportTimeFrame,
+  });
 
   // After a withdrawal or a trade, balances takes time to update, so we can't simply refetch balances right after
   // We check differences between availableBalance and totalBalance and poll balances until it is resolved
@@ -161,6 +176,11 @@ export const MarketOverview = (): JSX.Element => {
               marketInfo={marketInfo}
               baseAsset={state?.baseAsset}
               quoteAsset={state?.quoteAsset}
+              marketReport={marketReport}
+              setMarketReportPredefinedPeriod={setMarketReportPredefinedPeriod}
+              setMarketReportTimeFrame={setMarketReportTimeFrame}
+              marketReportTimeFrame={marketReportTimeFrame}
+              marketReportPredefinedPeriod={marketReportPredefinedPeriod}
             />
           </Col>
         </Row>

--- a/src/features/operator/Market/MarketOverview/index.tsx
+++ b/src/features/operator/Market/MarketOverview/index.tsx
@@ -179,7 +179,6 @@ export const MarketOverview = (): JSX.Element => {
               marketReport={marketReport}
               setMarketReportPredefinedPeriod={setMarketReportPredefinedPeriod}
               setMarketReportTimeFrame={setMarketReportTimeFrame}
-              marketReportTimeFrame={marketReportTimeFrame}
               marketReportPredefinedPeriod={marketReportPredefinedPeriod}
             />
           </Col>

--- a/src/features/operator/operator.api.ts
+++ b/src/features/operator/operator.api.ts
@@ -36,6 +36,7 @@ import type {
   GetMarketFragmenterBalanceReply,
   WithdrawMarketFragmenterReply,
   MarketReport,
+  TimeFrame,
 } from '../../api-spec/generated/js/operator_pb';
 import {
   ClaimFeeDepositsRequest,
@@ -320,14 +321,13 @@ export const operatorApi = createApi({
     // Market
     getMarketReport: build.query<
       MarketReport.AsObject | undefined,
-      { market: Market.AsObject; timeRange: TimeRange.AsObject }
+      { market: Market.AsObject | undefined; timeRange: TimeRange.AsObject; timeFrame: TimeFrame }
     >({
-      queryFn: async (arg, { getState }) => {
+      queryFn: async ({ market, timeRange, timeFrame }, { getState }) => {
         try {
           const state = getState() as RootState;
           const client = selectOperatorClient(state);
           const metadata = selectMacaroonCreds(state);
-          const { market, timeRange } = arg;
           if (!market || !timeRange) throw new Error('missing argument');
           const t = new TimeRange();
           t.setPredefinedPeriod(timeRange.predefinedPeriod);
@@ -341,7 +341,7 @@ export const operatorApi = createApi({
           newMarket.setBaseAsset(market.baseAsset);
           newMarket.setQuoteAsset(market.quoteAsset);
           const getMarketReportReply = await client.getMarketReport(
-            new GetMarketReportRequest().setMarket(newMarket).setTimeRange(t),
+            new GetMarketReportRequest().setMarket(newMarket).setTimeRange(t).setTimeFrame(timeFrame),
             metadata
           );
           return {


### PR DESCRIPTION
- Use predefined TimeRange/Timeframe combinations to simplify UI, not exposing TF to user
  - 1D => TF 1H
  - 7D => TF 4H
  - 1M => TF 1D
  - 3M => TF 1D
  - 1Y => TF 1W (Waiting for https://github.com/tdex-network/tdex-daemon/issues/569)
  - YTD => TF 1W
  - ALL => TF 1W 
  
- Default timeRange when entering the page is 1M

Please review @tiero 