### PR TITLE
[Market Overview] Display collected swap fees

### DIFF
--- a/src/common/DepositPage/index.tsx
+++ b/src/common/DepositPage/index.tsx
@@ -13,6 +13,7 @@ import { useTypedSelector } from '../../app/store';
 import alertOctogon from '../../assets/images/alert-octagon.svg';
 import { ReactComponent as chevronRight } from '../../assets/images/chevron-right.svg';
 import { HOME_ROUTE, MARKET_OVERVIEW_ROUTE } from '../../routes/constants';
+import { getAssetDataFromRegistry } from '../../utils';
 
 const { Text, Title } = Typography;
 
@@ -41,12 +42,11 @@ export const DepositPage = ({
 }: DepositPageProps): JSX.Element => {
   const navigate = useNavigate();
   const assetRegistry = useTypedSelector(({ settings }: RootState) => settings.assets);
+  const lbtcUnit = useTypedSelector(({ settings }) => settings.lbtcUnit);
   const network = useTypedSelector(({ settings }) => settings.network);
   const handleOptInFragmentationChange = (ev: CheckboxChangeEvent) => {
     setUseFragmenter(ev.target.checked);
   };
-  const baseAsset = assetRegistry[network].find((a) => a.asset_id === market?.baseAsset);
-  const quoteAsset = assetRegistry[network].find((a) => a.asset_id === market?.quoteAsset);
 
   return (
     <>
@@ -60,14 +60,24 @@ export const DepositPage = ({
             <Button
               type="link"
               className="dm-sans dm-sans__x"
-              onClick={() =>
+              onClick={() => {
+                const baseAsset = getAssetDataFromRegistry(
+                  market?.baseAsset || '',
+                  assetRegistry[network],
+                  lbtcUnit
+                );
+                const quoteAsset = getAssetDataFromRegistry(
+                  market?.quoteAsset || '',
+                  assetRegistry[network],
+                  lbtcUnit
+                );
                 navigate(MARKET_OVERVIEW_ROUTE, {
                   state: {
                     baseAsset,
                     quoteAsset,
                   },
-                })
-              }
+                });
+              }}
             >
               Market Overview
             </Button>

--- a/src/features/operator/Fee/FeeForm/index.tsx
+++ b/src/features/operator/Fee/FeeForm/index.tsx
@@ -139,9 +139,9 @@ export const FeeForm = ({
         feeRelativeInput: Number(feeRelative) / 100,
       }}
       onFinish={onFinish}
-      className={`${className} mb-4`}
+      className={className}
     >
-      <div className="panel panel__grey h-100">
+      <div className="panel panel__grey">
         <Row>
           <Col span={24}>
             <Title className="dm-sans dm-sans__x dm-sans__bold dm-sans__grey d-inline mr-4" level={3}>

--- a/src/features/operator/Market/CreateMarket/index.tsx
+++ b/src/features/operator/Market/CreateMarket/index.tsx
@@ -77,7 +77,7 @@ export const CreateMarket = (): JSX.Element => {
             <FeeForm
               baseAsset={baseAsset}
               quoteAsset={quoteAsset}
-              className={clx({ disabled: step < 2 })}
+              className={clx({ disabled: step < 2 }, 'mb-4')}
               incrementStep={incrementStep}
             />
             <div className={clx('panel panel__grey mb-4', { disabled: step < 3 })}>

--- a/src/features/operator/Market/ListMarkets/MarketListItem.tsx
+++ b/src/features/operator/Market/ListMarkets/MarketListItem.tsx
@@ -1,38 +1,19 @@
 import { Col, Row } from 'antd';
 import { useNavigate } from 'react-router-dom';
 
-import type { MarketInfo } from '../../../../api-spec/generated/js/operator_pb';
 import checkmark from '../../../../assets/images/checkmark.svg';
 import { CurrencyIcon } from '../../../../common/CurrencyIcon';
+import type { Asset } from '../../../../domain/asset';
 import { MARKET_OVERVIEW_ROUTE } from '../../../../routes/constants';
-import { useGetAssetDataQuery } from '../../../liquid.api';
 
 interface MarketListItemProps {
-  marketInfo: MarketInfo.AsObject;
+  baseAsset: Asset;
+  quoteAsset: Asset;
+  isTradable: boolean;
 }
 
-export const MarketListItem = ({ marketInfo }: MarketListItemProps): JSX.Element => {
+export const MarketListItem = ({ isTradable, baseAsset, quoteAsset }: MarketListItemProps): JSX.Element => {
   const navigate = useNavigate();
-  const { tradable } = marketInfo;
-  const { data: baseAssetFromQuery, error: baseAssetError } = useGetAssetDataQuery(
-    marketInfo.market?.baseAsset || ''
-  );
-  const { data: quoteAssetFromQuery, error: quoteAssetError } = useGetAssetDataQuery(
-    marketInfo.market?.quoteAsset || ''
-  );
-  // Last resort if GetAssetData fails
-  const baseAsset = baseAssetError
-    ? {
-        asset_id: marketInfo.market?.baseAsset,
-        ticker: marketInfo.market?.baseAsset?.substring(0, 4).toUpperCase(),
-      }
-    : baseAssetFromQuery;
-  const quoteAsset = quoteAssetError
-    ? {
-        asset_id: marketInfo.market?.quoteAsset,
-        ticker: marketInfo.market?.quoteAsset?.substring(0, 4).toUpperCase(),
-      }
-    : quoteAssetFromQuery;
 
   const handleClickMarketDetails = () => {
     navigate(MARKET_OVERVIEW_ROUTE, { state: { baseAsset, quoteAsset } });
@@ -52,7 +33,7 @@ export const MarketListItem = ({ marketInfo }: MarketListItemProps): JSX.Element
         </Col>
         <Col span={8}>
           <span className="">
-            {tradable ? (
+            {isTradable ? (
               <span className="status__open">
                 <span className="mr-1">Open</span>
                 <img className="checkmark" src={checkmark} alt="checkmark" />

--- a/src/features/operator/Market/ListMarkets/index.tsx
+++ b/src/features/operator/Market/ListMarkets/index.tsx
@@ -3,7 +3,7 @@ import './listMarkets.less';
 import { useEffect } from 'react';
 
 import { useTypedDispatch, useTypedSelector } from '../../../../app/store';
-import { getAllAssetIdsFromMarkets } from '../../../../utils';
+import { getAllAssetIdsFromMarkets, getAssetDataFromRegistry } from '../../../../utils';
 import { liquidApi } from '../../../liquid.api';
 import { setAsset } from '../../../settings/settingsSlice';
 import { useGetInfoQuery, useListMarketsQuery } from '../../operator.api';
@@ -16,6 +16,7 @@ export const ListMarkets = (): JSX.Element => {
   const { data: daemonInfo, isFetching: daemonInfoIsFetching } = useGetInfoQuery();
   const { data: listMarkets, error: listMarketsError } = useListMarketsQuery();
   const assetRegistry = useTypedSelector(({ settings }) => settings.assets);
+  const lbtcUnit = useTypedSelector(({ settings }) => settings.lbtcUnit);
   const network = useTypedSelector(({ settings }) => settings.network);
 
   // Add to store assets in markets
@@ -40,9 +41,26 @@ export const ListMarkets = (): JSX.Element => {
   return (
     <div id="list-markets">
       {listMarkets?.marketsList.length && network === daemonInfo?.network ? (
-        listMarkets?.marketsList.map((marketInfo, index) => (
-          <MarketListItem marketInfo={marketInfo} key={index} />
-        ))
+        listMarkets?.marketsList.map((marketInfo, index) => {
+          const baseAsset = getAssetDataFromRegistry(
+            marketInfo.market?.baseAsset || '',
+            assetRegistry[network],
+            lbtcUnit
+          );
+          const quoteAsset = getAssetDataFromRegistry(
+            marketInfo.market?.quoteAsset || '',
+            assetRegistry[network],
+            lbtcUnit
+          );
+          return baseAsset && quoteAsset ? (
+            <MarketListItem
+              baseAsset={baseAsset}
+              quoteAsset={quoteAsset}
+              isTradable={marketInfo.tradable}
+              key={index}
+            />
+          ) : null;
+        })
       ) : (
         <MarketListEmpty />
       )}

--- a/src/features/operator/Market/MarketOverview/index.tsx
+++ b/src/features/operator/Market/MarketOverview/index.tsx
@@ -22,7 +22,7 @@ const { Title } = Typography;
 
 export const MarketOverview = (): JSX.Element => {
   const navigate = useNavigate();
-  const { marketsLabelled } = useTypedSelector(({ settings }) => settings);
+  const marketsLabelled = useTypedSelector(({ settings }) => settings.marketsLabelled);
   const { state } = useLocation() as { state: { baseAsset: Asset; quoteAsset: Asset } };
   const [isBalanceUpdating, setIsBalanceUpdating] = useState<boolean>(false);
   const { data: marketBalance } = useGetMarketBalanceQuery(
@@ -166,13 +166,15 @@ export const MarketOverview = (): JSX.Element => {
                     <span className="dm-mono dm-mono__xx">
                       {marketReport?.totalCollectedFees?.baseAmount ?? 0}
                     </span>
-                    <span className="dm-sans dm-sans__x ml-2">{state?.baseAsset?.ticker ?? ''}</span>
+                    <span className="dm-sans dm-sans__x ml-2">{state?.baseAsset?.formattedTicker ?? ''}</span>
                   </div>
                   <div>
                     <span className="dm-mono dm-mono__xx">
                       {marketReport?.totalCollectedFees?.quoteAmount ?? 0}
                     </span>
-                    <span className="dm-sans dm-sans__x ml-2">{state?.quoteAsset?.ticker ?? ''}</span>
+                    <span className="dm-sans dm-sans__x ml-2">
+                      {state?.quoteAsset?.formattedTicker ?? ''}
+                    </span>
                   </div>
                 </Col>
               </Row>

--- a/src/features/operator/Market/MarketOverview/index.tsx
+++ b/src/features/operator/Market/MarketOverview/index.tsx
@@ -10,6 +10,7 @@ import { ReactComponent as depositIcon } from '../../../../assets/images/deposit
 import { MarketIcons } from '../../../../common/MarketIcons';
 import type { Asset } from '../../../../domain/asset';
 import { HOME_ROUTE, MARKET_DEPOSIT_ROUTE, MARKET_WITHDRAW_ROUTE } from '../../../../routes/constants';
+import { fromSatsToUnitOrFractional, isLbtcTicker } from '../../../../utils';
 import { FeeForm } from '../../Fee/FeeForm';
 import { TxsTable } from '../../TxsTable';
 import { useGetMarketBalanceQuery, useGetMarketInfoQuery, useGetMarketReportQuery } from '../../operator.api';
@@ -23,6 +24,7 @@ const { Title } = Typography;
 export const MarketOverview = (): JSX.Element => {
   const navigate = useNavigate();
   const marketsLabelled = useTypedSelector(({ settings }) => settings.marketsLabelled);
+  const lbtcUnit = useTypedSelector(({ settings }) => settings.lbtcUnit);
   const { state } = useLocation() as { state: { baseAsset: Asset; quoteAsset: Asset } };
   const [isBalanceUpdating, setIsBalanceUpdating] = useState<boolean>(false);
   const { data: marketBalance } = useGetMarketBalanceQuery(
@@ -161,16 +163,26 @@ export const MarketOverview = (): JSX.Element => {
                 </Col>
               </Row>
               <Row align="middle">
-                <Col span={8}>
+                <Col>
                   <div>
                     <span className="dm-mono dm-mono__xx">
-                      {marketReport?.totalCollectedFees?.baseAmount ?? 0}
+                      {fromSatsToUnitOrFractional(
+                        marketReport?.totalCollectedFees?.baseAmount ?? 0,
+                        state?.baseAsset?.precision,
+                        isLbtcTicker(state?.baseAsset?.ticker),
+                        lbtcUnit
+                      )}
                     </span>
                     <span className="dm-sans dm-sans__x ml-2">{state?.baseAsset?.formattedTicker ?? ''}</span>
                   </div>
                   <div>
                     <span className="dm-mono dm-mono__xx">
-                      {marketReport?.totalCollectedFees?.quoteAmount ?? 0}
+                      {fromSatsToUnitOrFractional(
+                        marketReport?.totalCollectedFees?.quoteAmount ?? 0,
+                        state?.quoteAsset?.precision,
+                        isLbtcTicker(state?.quoteAsset?.ticker),
+                        lbtcUnit
+                      )}
                     </span>
                     <span className="dm-sans dm-sans__x ml-2">
                       {state?.quoteAsset?.formattedTicker ?? ''}

--- a/src/features/operator/Market/MarketOverview/index.tsx
+++ b/src/features/operator/Market/MarketOverview/index.tsx
@@ -150,7 +150,26 @@ export const MarketOverview = (): JSX.Element => {
           </Col>
         </Row>
         <Row className="mb-8" gutter={{ xs: 4, sm: 8, md: 12 }}>
-          <Col span={8}>
+          <Col span={8} className="h-100">
+            <div className="panel panel__grey mb-4">
+              <Row>
+                <Col span={24}>
+                  <Title className="dm-sans dm-sans__x dm-sans__bold dm-sans__grey d-inline mr-4" level={3}>
+                    Collected Swap Fees
+                  </Title>
+                  <InfoCircleOutlined className="grey" />
+                </Col>
+              </Row>
+              <Row align="middle">
+                <Col span={8}>
+                  <span className="dm-sans dm-sans__xx">
+                    {marketReport?.totalCollectedFees?.baseAmount ?? 0}
+                  </span>
+                  <span className="dm-sans dm-sans__x ml-2">{state?.baseAsset?.ticker ?? ''}</span>
+                </Col>
+              </Row>
+            </div>
+
             {/* Render FeeForm only when marketInfo is ready */}
             {/* To ensure AntD form initialValues are correct */}
             {marketInfo ? (

--- a/src/features/operator/Market/MarketOverview/index.tsx
+++ b/src/features/operator/Market/MarketOverview/index.tsx
@@ -162,10 +162,18 @@ export const MarketOverview = (): JSX.Element => {
               </Row>
               <Row align="middle">
                 <Col span={8}>
-                  <span className="dm-sans dm-sans__xx">
-                    {marketReport?.totalCollectedFees?.baseAmount ?? 0}
-                  </span>
-                  <span className="dm-sans dm-sans__x ml-2">{state?.baseAsset?.ticker ?? ''}</span>
+                  <div>
+                    <span className="dm-mono dm-mono__xx">
+                      {marketReport?.totalCollectedFees?.baseAmount ?? 0}
+                    </span>
+                    <span className="dm-sans dm-sans__x ml-2">{state?.baseAsset?.ticker ?? ''}</span>
+                  </div>
+                  <div>
+                    <span className="dm-mono dm-mono__xx">
+                      {marketReport?.totalCollectedFees?.quoteAmount ?? 0}
+                    </span>
+                    <span className="dm-sans dm-sans__x ml-2">{state?.quoteAsset?.ticker ?? ''}</span>
+                  </div>
                 </Col>
               </Row>
             </div>


### PR DESCRIPTION
It closes #285 
- Display collected swap fees, base and quote, in lbtc unit or fractional.
- Get asset data from `getAssetDataFromRegistry` to avoid network request and to use `formattedTicker` Asset property.

Please review @tiero 