### PR TITLE
Add fromUnitToUnit helper

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,4 @@ jobs:
       - run: yarn
       - run: yarn build
       - run: yarn lint
-      # - run: yarn test
+      - run: yarn test

--- a/src/utils/unitConvert.spec.ts
+++ b/src/utils/unitConvert.spec.ts
@@ -4,77 +4,87 @@ import { fromSatsToUnitOrFractional, fromUnitToUnit } from './unitConvert';
 // https://jestjs.io/docs/expect#tobeclosetonumber-numdigits
 
 describe('unit conversion', () => {
-  it('should convert liquid bitcoin from unit to unit', async () => {
-    expect(fromUnitToUnit(1, 'L-BTC', 'L-sats')).toBe('100000000');
-    expect(fromUnitToUnit(1, 'L-BTC', 'L-bits')).toBe('1000000');
-    expect(fromUnitToUnit(1, 'L-BTC', 'L-mBTC')).toBe('1000');
-    expect(fromUnitToUnit(1, 'L-BTC', 'L-BTC')).toBe('1');
-    //
-    expect(fromUnitToUnit(1, 'L-mBTC', 'L-sats')).toBe('100000');
-    expect(fromUnitToUnit(1, 'L-mBTC', 'L-bits')).toBe('1000');
-    expect(fromUnitToUnit(1, 'L-mBTC', 'L-mBTC')).toBe('1');
-    expect(fromUnitToUnit(1, 'L-mBTC', 'L-BTC')).toBe('0.001');
-    //
-    expect(fromUnitToUnit(1, 'L-bits', 'L-sats')).toBe('100');
-    expect(fromUnitToUnit(1, 'L-bits', 'L-bits')).toBe('1');
-    expect(fromUnitToUnit(1, 'L-bits', 'L-mBTC')).toBe('0.001');
-    expect(fromUnitToUnit(1, 'L-bits', 'L-BTC')).toBe('0.000001');
-    //
-    expect(fromUnitToUnit(1, 'L-sats', 'L-sats')).toBe('1');
-    expect(fromUnitToUnit(1, 'L-sats', 'L-bits')).toBe('0.01');
-    expect(fromUnitToUnit(1, 'L-sats', 'L-mBTC')).toBe('0.00001');
-    expect(fromUnitToUnit(1, 'L-sats', 'L-BTC')).toBe('0.00000001');
-    ////
-    expect(fromUnitToUnit(5.56789512, 'L-BTC', 'L-sats')).toBe('556789512');
-    expect(fromUnitToUnit(5.56789512, 'L-BTC', 'L-bits')).toBe('5567895.12');
-    expect(fromUnitToUnit(5.56789512, 'L-BTC', 'L-mBTC')).toBe('5567.89512');
-    expect(fromUnitToUnit(5.56789512, 'L-BTC', 'L-BTC')).toBe('5.56789512');
-    //
-    expect(fromUnitToUnit(5.56789, 'L-mBTC', 'L-sats')).toBe('556789');
-    expect(fromUnitToUnit(5.56789, 'L-mBTC', 'L-bits')).toBe('5567.89');
-    expect(fromUnitToUnit(5.56789, 'L-mBTC', 'L-mBTC')).toBe('5.56789');
-    expect(fromUnitToUnit(5.56789, 'L-mBTC', 'L-BTC')).toBe('0.00556789');
-    //
-    expect(fromUnitToUnit(5.56, 'L-bits', 'L-sats')).toBe('556');
-    expect(fromUnitToUnit(5.56, 'L-bits', 'L-bits')).toBe('5.56');
-    expect(fromUnitToUnit(5.56, 'L-bits', 'L-mBTC')).toBe('0.00556');
-    expect(fromUnitToUnit(5.56, 'L-bits', 'L-BTC')).toBe('0.00000556');
-    //
-    expect(fromUnitToUnit(556, 'L-sats', 'L-sats')).toBe('556');
-    expect(fromUnitToUnit(556, 'L-sats', 'L-bits')).toBe('5.56');
-    expect(fromUnitToUnit(556, 'L-sats', 'L-mBTC')).toBe('0.00556');
-    expect(fromUnitToUnit(556, 'L-sats', 'L-BTC')).toBe('0.00000556');
+  describe('fromUnitToUnit', () => {
+    it('should convert liquid bitcoin from unit to unit', async () => {
+      expect(fromUnitToUnit(1, 'L-BTC', 'L-sats')).toBe('100000000');
+      expect(fromUnitToUnit(1, 'L-BTC', 'L-bits')).toBe('1000000');
+      expect(fromUnitToUnit(1, 'L-BTC', 'L-mBTC')).toBe('1000');
+      expect(fromUnitToUnit(1, 'L-BTC', 'L-BTC')).toBe('1');
+      //
+      expect(fromUnitToUnit(1, 'L-mBTC', 'L-sats')).toBe('100000');
+      expect(fromUnitToUnit(1, 'L-mBTC', 'L-bits')).toBe('1000');
+      expect(fromUnitToUnit(1, 'L-mBTC', 'L-mBTC')).toBe('1');
+      expect(fromUnitToUnit(1, 'L-mBTC', 'L-BTC')).toBe('0.001');
+      //
+      expect(fromUnitToUnit(1, 'L-bits', 'L-sats')).toBe('100');
+      expect(fromUnitToUnit(1, 'L-bits', 'L-bits')).toBe('1');
+      expect(fromUnitToUnit(1, 'L-bits', 'L-mBTC')).toBe('0.001');
+      expect(fromUnitToUnit(1, 'L-bits', 'L-BTC')).toBe('0.000001');
+      //
+      expect(fromUnitToUnit(1, 'L-sats', 'L-sats')).toBe('1');
+      expect(fromUnitToUnit(1, 'L-sats', 'L-bits')).toBe('0.01');
+      expect(fromUnitToUnit(1, 'L-sats', 'L-mBTC')).toBe('0.00001');
+      expect(fromUnitToUnit(1, 'L-sats', 'L-BTC')).toBe('0.00000001');
+      ////
+      expect(fromUnitToUnit(5.56789512, 'L-BTC', 'L-sats')).toBe('556789512');
+      expect(fromUnitToUnit(5.56789512, 'L-BTC', 'L-bits')).toBe('5567895.12');
+      expect(fromUnitToUnit(5.56789512, 'L-BTC', 'L-mBTC')).toBe('5567.89512');
+      expect(fromUnitToUnit(5.56789512, 'L-BTC', 'L-BTC')).toBe('5.56789512');
+      //
+      expect(fromUnitToUnit(5.56789, 'L-mBTC', 'L-sats')).toBe('556789');
+      expect(fromUnitToUnit(5.56789, 'L-mBTC', 'L-bits')).toBe('5567.89');
+      expect(fromUnitToUnit(5.56789, 'L-mBTC', 'L-mBTC')).toBe('5.56789');
+      expect(fromUnitToUnit(5.56789, 'L-mBTC', 'L-BTC')).toBe('0.00556789');
+      //
+      expect(fromUnitToUnit(5.56, 'L-bits', 'L-sats')).toBe('556');
+      expect(fromUnitToUnit(5.56, 'L-bits', 'L-bits')).toBe('5.56');
+      expect(fromUnitToUnit(5.56, 'L-bits', 'L-mBTC')).toBe('0.00556');
+      expect(fromUnitToUnit(5.56, 'L-bits', 'L-BTC')).toBe('0.00000556');
+      //
+      expect(fromUnitToUnit(556, 'L-sats', 'L-sats')).toBe('556');
+      expect(fromUnitToUnit(556, 'L-sats', 'L-bits')).toBe('5.56');
+      expect(fromUnitToUnit(556, 'L-sats', 'L-mBTC')).toBe('0.00556');
+      expect(fromUnitToUnit(556, 'L-sats', 'L-BTC')).toBe('0.00000556');
+    });
+
+    it('should throw with "Invalid amount: too many decimal places"', async () => {
+      expect(() => fromUnitToUnit(5.56789, 'L-bits', 'L-BTC')).toThrow(
+        'Invalid amount: too many decimal places'
+      );
+      expect(() => fromUnitToUnit(5.56789, 'L-sats', 'L-BTC')).toThrow(
+        'Invalid amount: too many decimal places'
+      );
+    });
   });
 
-  it('should throw with "Invalid amount: too many decimal places"', async () => {
-    expect(() => fromUnitToUnit(5.56789, 'L-bits', 'L-BTC')).toThrow(
-      'Invalid amount: too many decimal places'
-    );
-    expect(() => fromUnitToUnit(5.56789, 'L-sats', 'L-BTC')).toThrow(
-      'Invalid amount: too many decimal places'
-    );
-  });
+  describe('fromSatsToUnitOrFractional', () => {
+    it('should convert liquid bitcoin from sats to unit', async () => {
+      expect(fromSatsToUnitOrFractional(556, 8, true, 'L-sats')).toBe('556');
+      expect(fromSatsToUnitOrFractional(556, 8, true, 'L-bits')).toBe('5.56');
+      expect(fromSatsToUnitOrFractional(556, 8, true, 'L-mBTC')).toBe('0.00556');
+      expect(fromSatsToUnitOrFractional(556, 8, true, 'L-BTC')).toBe('0.00000556');
+    });
 
-  it('should convert liquid bitcoin from sats to unit', async () => {
-    expect(fromSatsToUnitOrFractional(556, 8, true, 'L-sats')).toBe('556');
-    expect(fromSatsToUnitOrFractional(556, 8, true, 'L-bits')).toBe('5.56');
-    expect(fromSatsToUnitOrFractional(556, 8, true, 'L-mBTC')).toBe('0.00556');
-    expect(fromSatsToUnitOrFractional(556, 8, true, 'L-BTC')).toBe('0.00000556');
-  });
+    it('should convert non-btc asset from sats to fractional (precision 8)', async () => {
+      expect(fromSatsToUnitOrFractional(556, 8, false)).toBe('0.00000556');
+      expect(fromSatsToUnitOrFractional(55678912345, 8, false)).toBe('556.78912345');
+      // LBTC unit is just ignored
+      expect(fromSatsToUnitOrFractional(55678912345, 8, false, 'L-mBTC')).toBe('556.78912345');
+      expect(fromSatsToUnitOrFractional(55678912345, 8, false, 'L-BTC')).toBe('556.78912345');
+    });
 
-  it('should convert non-btc asset from sats to fractional (precision 8)', async () => {
-    expect(fromSatsToUnitOrFractional(556, 8, false)).toBe('0.00000556');
-    expect(fromSatsToUnitOrFractional(55678912345, 8, false)).toBe('556.78912345');
-    // LBTC unit is just ignored
-    expect(fromSatsToUnitOrFractional(55678912345, 8, false, 'L-mBTC')).toBe('556.78912345');
-    expect(fromSatsToUnitOrFractional(55678912345, 8, false, 'L-BTC')).toBe('556.78912345');
-  });
+    it('should convert non-btc asset from sats to fractional (precision 5)', async () => {
+      expect(fromSatsToUnitOrFractional(55678912345, 5, false)).toBe('556789.12345');
+    });
 
-  it('should convert non-btc asset from sats to fractional (precision 5)', async () => {
-    expect(fromSatsToUnitOrFractional(55678912345, 5, false)).toBe('556789.12345');
-  });
+    it('should convert non-btc asset from sats to fractional (precision 0)', async () => {
+      expect(fromSatsToUnitOrFractional(55678912345, 0, false)).toBe('55678912345');
+    });
 
-  it('should convert non-btc asset from sats to fractional (precision 0)', async () => {
-    expect(fromSatsToUnitOrFractional(55678912345, 0, false)).toBe('55678912345');
+    it('should throw with "Amount should be specified in satoshis"', async () => {
+      expect(() => fromSatsToUnitOrFractional(5.1234, 8, false, 'L-BTC')).toThrow(
+        'Amount should be specified in satoshis'
+      );
+    });
   });
 });

--- a/src/utils/unitConvert.spec.ts
+++ b/src/utils/unitConvert.spec.ts
@@ -1,70 +1,80 @@
-import assert from 'assert';
-
 import { fromSatsToUnitOrFractional, fromUnitToUnit } from './unitConvert';
+
+// Note: Jest toBe() can compare numbers and strings, but for floats we need to use toBeCloseTo()
+// https://jestjs.io/docs/expect#tobeclosetonumber-numdigits
 
 describe('unit conversion', () => {
   it('should convert liquid bitcoin from unit to unit', async () => {
-    assert.strictEqual(fromUnitToUnit(1, 'L-BTC', 'L-sats'), '100000000');
-    assert.strictEqual(fromUnitToUnit(1, 'L-BTC', 'L-bits'), '1000000');
-    assert.strictEqual(fromUnitToUnit(1, 'L-BTC', 'L-mBTC'), '1000');
-    assert.strictEqual(fromUnitToUnit(1, 'L-BTC', 'L-BTC'), '1');
+    expect(fromUnitToUnit(1, 'L-BTC', 'L-sats')).toBe('100000000');
+    expect(fromUnitToUnit(1, 'L-BTC', 'L-bits')).toBe('1000000');
+    expect(fromUnitToUnit(1, 'L-BTC', 'L-mBTC')).toBe('1000');
+    expect(fromUnitToUnit(1, 'L-BTC', 'L-BTC')).toBe('1');
     //
-    assert.strictEqual(fromUnitToUnit(1, 'L-mBTC', 'L-sats'), '100000');
-    assert.strictEqual(fromUnitToUnit(1, 'L-mBTC', 'L-bits'), '1000');
-    assert.strictEqual(fromUnitToUnit(1, 'L-mBTC', 'L-mBTC'), '1');
-    assert.strictEqual(fromUnitToUnit(1, 'L-mBTC', 'L-BTC'), '0.001');
+    expect(fromUnitToUnit(1, 'L-mBTC', 'L-sats')).toBe('100000');
+    expect(fromUnitToUnit(1, 'L-mBTC', 'L-bits')).toBe('1000');
+    expect(fromUnitToUnit(1, 'L-mBTC', 'L-mBTC')).toBe('1');
+    expect(fromUnitToUnit(1, 'L-mBTC', 'L-BTC')).toBe('0.001');
     //
-    assert.strictEqual(fromUnitToUnit(1, 'L-bits', 'L-sats'), '100');
-    assert.strictEqual(fromUnitToUnit(1, 'L-bits', 'L-bits'), '1');
-    assert.strictEqual(fromUnitToUnit(1, 'L-bits', 'L-mBTC'), '0.001');
-    assert.strictEqual(fromUnitToUnit(1, 'L-bits', 'L-BTC'), '0.000001');
+    expect(fromUnitToUnit(1, 'L-bits', 'L-sats')).toBe('100');
+    expect(fromUnitToUnit(1, 'L-bits', 'L-bits')).toBe('1');
+    expect(fromUnitToUnit(1, 'L-bits', 'L-mBTC')).toBe('0.001');
+    expect(fromUnitToUnit(1, 'L-bits', 'L-BTC')).toBe('0.000001');
     //
-    assert.strictEqual(fromUnitToUnit(1, 'L-sats', 'L-sats'), '1');
-    assert.strictEqual(fromUnitToUnit(1, 'L-sats', 'L-bits'), '0.01');
-    assert.strictEqual(fromUnitToUnit(1, 'L-sats', 'L-mBTC'), '0.00001');
-    assert.strictEqual(fromUnitToUnit(1, 'L-sats', 'L-BTC'), '0.00000001');
+    expect(fromUnitToUnit(1, 'L-sats', 'L-sats')).toBe('1');
+    expect(fromUnitToUnit(1, 'L-sats', 'L-bits')).toBe('0.01');
+    expect(fromUnitToUnit(1, 'L-sats', 'L-mBTC')).toBe('0.00001');
+    expect(fromUnitToUnit(1, 'L-sats', 'L-BTC')).toBe('0.00000001');
     ////
-    assert.strictEqual(fromUnitToUnit(5.56789512, 'L-BTC', 'L-sats'), '556789512');
-    assert.strictEqual(fromUnitToUnit(5.56789512, 'L-BTC', 'L-bits'), '5567895.12');
-    assert.strictEqual(fromUnitToUnit(5.56789512, 'L-BTC', 'L-mBTC'), '5567.89512');
-    assert.strictEqual(fromUnitToUnit(5.56789512, 'L-BTC', 'L-BTC'), '5.56789512');
+    expect(fromUnitToUnit(5.56789512, 'L-BTC', 'L-sats')).toBe('556789512');
+    expect(fromUnitToUnit(5.56789512, 'L-BTC', 'L-bits')).toBe('5567895.12');
+    expect(fromUnitToUnit(5.56789512, 'L-BTC', 'L-mBTC')).toBe('5567.89512');
+    expect(fromUnitToUnit(5.56789512, 'L-BTC', 'L-BTC')).toBe('5.56789512');
     //
-    assert.strictEqual(fromUnitToUnit(5.56789, 'L-mBTC', 'L-sats'), '556789');
-    assert.strictEqual(fromUnitToUnit(5.56789, 'L-mBTC', 'L-bits'), '5567.89');
-    assert.strictEqual(fromUnitToUnit(5.56789, 'L-mBTC', 'L-mBTC'), '5.56789');
-    assert.strictEqual(fromUnitToUnit(5.56789, 'L-mBTC', 'L-BTC'), '0.00556789');
+    expect(fromUnitToUnit(5.56789, 'L-mBTC', 'L-sats')).toBe('556789');
+    expect(fromUnitToUnit(5.56789, 'L-mBTC', 'L-bits')).toBe('5567.89');
+    expect(fromUnitToUnit(5.56789, 'L-mBTC', 'L-mBTC')).toBe('5.56789');
+    expect(fromUnitToUnit(5.56789, 'L-mBTC', 'L-BTC')).toBe('0.00556789');
     //
-    assert.strictEqual(fromUnitToUnit(5.56, 'L-bits', 'L-sats'), '556');
-    assert.strictEqual(fromUnitToUnit(5.56, 'L-bits', 'L-bits'), '5.56');
-    assert.strictEqual(fromUnitToUnit(5.56, 'L-bits', 'L-mBTC'), '0.00556');
-    assert.strictEqual(fromUnitToUnit(5.56, 'L-bits', 'L-BTC'), '0.00000556');
+    expect(fromUnitToUnit(5.56, 'L-bits', 'L-sats')).toBe('556');
+    expect(fromUnitToUnit(5.56, 'L-bits', 'L-bits')).toBe('5.56');
+    expect(fromUnitToUnit(5.56, 'L-bits', 'L-mBTC')).toBe('0.00556');
+    expect(fromUnitToUnit(5.56, 'L-bits', 'L-BTC')).toBe('0.00000556');
     //
-    assert.strictEqual(fromUnitToUnit(556, 'L-sats', 'L-sats'), '556');
-    assert.strictEqual(fromUnitToUnit(556, 'L-sats', 'L-bits'), '5.56');
-    assert.strictEqual(fromUnitToUnit(556, 'L-sats', 'L-mBTC'), '0.00556');
-    assert.strictEqual(fromUnitToUnit(556, 'L-sats', 'L-BTC'), '0.00000556');
+    expect(fromUnitToUnit(556, 'L-sats', 'L-sats')).toBe('556');
+    expect(fromUnitToUnit(556, 'L-sats', 'L-bits')).toBe('5.56');
+    expect(fromUnitToUnit(556, 'L-sats', 'L-mBTC')).toBe('0.00556');
+    expect(fromUnitToUnit(556, 'L-sats', 'L-BTC')).toBe('0.00000556');
+  });
+
+  it('should throw with "Invalid amount: too many decimal places"', async () => {
+    expect(() => fromUnitToUnit(5.56789, 'L-bits', 'L-BTC')).toThrow(
+      'Invalid amount: too many decimal places'
+    );
+    expect(() => fromUnitToUnit(5.56789, 'L-sats', 'L-BTC')).toThrow(
+      'Invalid amount: too many decimal places'
+    );
   });
 
   it('should convert liquid bitcoin from sats to unit', async () => {
-    assert.strictEqual(fromSatsToUnitOrFractional(556, 8, true, 'L-sats'), '556');
-    assert.strictEqual(fromSatsToUnitOrFractional(556, 8, true, 'L-bits'), '5.56');
-    assert.strictEqual(fromSatsToUnitOrFractional(556, 8, true, 'L-mBTC'), '0.00556');
-    assert.strictEqual(fromSatsToUnitOrFractional(556, 8, true, 'L-BTC'), '0.00000556');
+    expect(fromSatsToUnitOrFractional(556, 8, true, 'L-sats')).toBe('556');
+    expect(fromSatsToUnitOrFractional(556, 8, true, 'L-bits')).toBe('5.56');
+    expect(fromSatsToUnitOrFractional(556, 8, true, 'L-mBTC')).toBe('0.00556');
+    expect(fromSatsToUnitOrFractional(556, 8, true, 'L-BTC')).toBe('0.00000556');
   });
 
   it('should convert non-btc asset from sats to fractional (precision 8)', async () => {
-    assert.strictEqual(fromSatsToUnitOrFractional(556, 8, false), '0.00000556');
-    assert.strictEqual(fromSatsToUnitOrFractional(55678912345, 8, false), '556.78912345');
+    expect(fromSatsToUnitOrFractional(556, 8, false)).toBe('0.00000556');
+    expect(fromSatsToUnitOrFractional(55678912345, 8, false)).toBe('556.78912345');
     // LBTC unit is just ignored
-    assert.strictEqual(fromSatsToUnitOrFractional(55678912345, 8, false, 'L-mBTC'), '556.78912345');
-    assert.strictEqual(fromSatsToUnitOrFractional(55678912345, 8, false, 'L-BTC'), '556.78912345');
+    expect(fromSatsToUnitOrFractional(55678912345, 8, false, 'L-mBTC')).toBe('556.78912345');
+    expect(fromSatsToUnitOrFractional(55678912345, 8, false, 'L-BTC')).toBe('556.78912345');
   });
 
   it('should convert non-btc asset from sats to fractional (precision 5)', async () => {
-    assert.strictEqual(fromSatsToUnitOrFractional(55678912345, 5, false), '556789.12345');
+    expect(fromSatsToUnitOrFractional(55678912345, 5, false)).toBe('556789.12345');
   });
 
   it('should convert non-btc asset from sats to fractional (precision 0)', async () => {
-    assert.strictEqual(fromSatsToUnitOrFractional(55678912345, 0, false), '55678912345');
+    expect(fromSatsToUnitOrFractional(55678912345, 0, false)).toBe('55678912345');
   });
 });

--- a/src/utils/unitConvert.spec.ts
+++ b/src/utils/unitConvert.spec.ts
@@ -1,0 +1,70 @@
+import assert from 'assert';
+
+import { fromSatsToUnitOrFractional, fromUnitToUnit } from './unitConvert';
+
+describe('unit conversion', () => {
+  it('should convert liquid bitcoin from unit to unit', async () => {
+    assert.strictEqual(fromUnitToUnit(1, 'L-BTC', 'L-sats'), '100000000');
+    assert.strictEqual(fromUnitToUnit(1, 'L-BTC', 'L-bits'), '1000000');
+    assert.strictEqual(fromUnitToUnit(1, 'L-BTC', 'L-mBTC'), '1000');
+    assert.strictEqual(fromUnitToUnit(1, 'L-BTC', 'L-BTC'), '1');
+    //
+    assert.strictEqual(fromUnitToUnit(1, 'L-mBTC', 'L-sats'), '100000');
+    assert.strictEqual(fromUnitToUnit(1, 'L-mBTC', 'L-bits'), '1000');
+    assert.strictEqual(fromUnitToUnit(1, 'L-mBTC', 'L-mBTC'), '1');
+    assert.strictEqual(fromUnitToUnit(1, 'L-mBTC', 'L-BTC'), '0.001');
+    //
+    assert.strictEqual(fromUnitToUnit(1, 'L-bits', 'L-sats'), '100');
+    assert.strictEqual(fromUnitToUnit(1, 'L-bits', 'L-bits'), '1');
+    assert.strictEqual(fromUnitToUnit(1, 'L-bits', 'L-mBTC'), '0.001');
+    assert.strictEqual(fromUnitToUnit(1, 'L-bits', 'L-BTC'), '0.000001');
+    //
+    assert.strictEqual(fromUnitToUnit(1, 'L-sats', 'L-sats'), '1');
+    assert.strictEqual(fromUnitToUnit(1, 'L-sats', 'L-bits'), '0.01');
+    assert.strictEqual(fromUnitToUnit(1, 'L-sats', 'L-mBTC'), '0.00001');
+    assert.strictEqual(fromUnitToUnit(1, 'L-sats', 'L-BTC'), '0.00000001');
+    ////
+    assert.strictEqual(fromUnitToUnit(5.56789512, 'L-BTC', 'L-sats'), '556789512');
+    assert.strictEqual(fromUnitToUnit(5.56789512, 'L-BTC', 'L-bits'), '5567895.12');
+    assert.strictEqual(fromUnitToUnit(5.56789512, 'L-BTC', 'L-mBTC'), '5567.89512');
+    assert.strictEqual(fromUnitToUnit(5.56789512, 'L-BTC', 'L-BTC'), '5.56789512');
+    //
+    assert.strictEqual(fromUnitToUnit(5.56789, 'L-mBTC', 'L-sats'), '556789');
+    assert.strictEqual(fromUnitToUnit(5.56789, 'L-mBTC', 'L-bits'), '5567.89');
+    assert.strictEqual(fromUnitToUnit(5.56789, 'L-mBTC', 'L-mBTC'), '5.56789');
+    assert.strictEqual(fromUnitToUnit(5.56789, 'L-mBTC', 'L-BTC'), '0.00556789');
+    //
+    assert.strictEqual(fromUnitToUnit(5.56, 'L-bits', 'L-sats'), '556');
+    assert.strictEqual(fromUnitToUnit(5.56, 'L-bits', 'L-bits'), '5.56');
+    assert.strictEqual(fromUnitToUnit(5.56, 'L-bits', 'L-mBTC'), '0.00556');
+    assert.strictEqual(fromUnitToUnit(5.56, 'L-bits', 'L-BTC'), '0.00000556');
+    //
+    assert.strictEqual(fromUnitToUnit(556, 'L-sats', 'L-sats'), '556');
+    assert.strictEqual(fromUnitToUnit(556, 'L-sats', 'L-bits'), '5.56');
+    assert.strictEqual(fromUnitToUnit(556, 'L-sats', 'L-mBTC'), '0.00556');
+    assert.strictEqual(fromUnitToUnit(556, 'L-sats', 'L-BTC'), '0.00000556');
+  });
+
+  it('should convert liquid bitcoin from sats to unit', async () => {
+    assert.strictEqual(fromSatsToUnitOrFractional(556, 8, true, 'L-sats'), '556');
+    assert.strictEqual(fromSatsToUnitOrFractional(556, 8, true, 'L-bits'), '5.56');
+    assert.strictEqual(fromSatsToUnitOrFractional(556, 8, true, 'L-mBTC'), '0.00556');
+    assert.strictEqual(fromSatsToUnitOrFractional(556, 8, true, 'L-BTC'), '0.00000556');
+  });
+
+  it('should convert non-btc asset from sats to fractional (precision 8)', async () => {
+    assert.strictEqual(fromSatsToUnitOrFractional(556, 8, false), '0.00000556');
+    assert.strictEqual(fromSatsToUnitOrFractional(55678912345, 8, false), '556.78912345');
+    // LBTC unit is just ignored
+    assert.strictEqual(fromSatsToUnitOrFractional(55678912345, 8, false, 'L-mBTC'), '556.78912345');
+    assert.strictEqual(fromSatsToUnitOrFractional(55678912345, 8, false, 'L-BTC'), '556.78912345');
+  });
+
+  it('should convert non-btc asset from sats to fractional (precision 5)', async () => {
+    assert.strictEqual(fromSatsToUnitOrFractional(55678912345, 5, false), '556789.12345');
+  });
+
+  it('should convert non-btc asset from sats to fractional (precision 0)', async () => {
+    assert.strictEqual(fromSatsToUnitOrFractional(55678912345, 0, false), '55678912345');
+  });
+});

--- a/src/utils/unitConvert.ts
+++ b/src/utils/unitConvert.ts
@@ -36,14 +36,15 @@ export function fromSatsToUnitOrFractional(
   isLbtc: boolean,
   lbtcUnit?: LbtcUnit
 ): string {
+  // Check that sats is not a float
+  if (Number(sats) === sats && sats % 1 !== 0) {
+    throw new Error('Amount should be specified in satoshis');
+  }
   try {
     const unit = isLbtc ? lbtcUnit : undefined;
-    const decimalPlaces = lbtcUnitOrTickerToFractionalDigits(isLbtc ? lbtcUnit ?? '' : '', precision);
-    return removeInsignificant(
-      new Big(sats)
-        .div(new Big(10).pow(new Big(precision).minus(unitToExponent(unit)).toNumber()))
-        .toFixed(decimalPlaces)
-    );
+    return new Big(sats)
+      .div(new Big(10).pow(new Big(precision).minus(unitToExponent(unit)).toNumber()))
+      .toFixed();
   } catch (err) {
     console.error(err);
     return 'N/A';
@@ -62,13 +63,9 @@ export function fromUnitToUnit(amount: number, lbtcUnitFrom: LbtcUnit, lbtcUnitT
   if (decimalPlaces > lbtcUnitOrTickerToFractionalDigits(lbtcUnitFrom, 8)) {
     throw new Error('Invalid amount: too many decimal places');
   }
-  return removeInsignificant(
-    new Big(amount)
-      .div(
-        new Big(10).pow(new Big(unitToExponent(lbtcUnitFrom)).minus(unitToExponent(lbtcUnitTo)).toNumber())
-      )
-      .toFixed(lbtcUnitOrTickerToFractionalDigits(lbtcUnitTo, 8))
-  );
+  return new Big(amount)
+    .div(new Big(10).pow(new Big(unitToExponent(lbtcUnitFrom)).minus(unitToExponent(lbtcUnitTo)).toNumber()))
+    .toFixed();
 }
 
 /**

--- a/src/utils/unitConvert.ts
+++ b/src/utils/unitConvert.ts
@@ -4,6 +4,9 @@ import type { LbtcUnit } from './constants';
 import { defaultPrecision, LBTC_UNITS } from './constants';
 import { includes } from './snippets';
 
+/**
+ * Remove leading and trailing zeros
+ */
 const rxLeadingZeros = /^[\s0]{2,}/;
 const rxEndingZeros = /[\s0]+$/;
 const removeInsignificant = (str: string) => {

--- a/src/utils/unitConvert.ts
+++ b/src/utils/unitConvert.ts
@@ -38,9 +38,12 @@ export function fromSatsToUnitOrFractional(
 ): string {
   try {
     const unit = isLbtc ? lbtcUnit : undefined;
-    return new Big(sats)
-      .div(new Big(10).pow(new Big(precision).minus(unitToExponent(unit)).toNumber()))
-      .toFixed();
+    const decimalPlaces = lbtcUnitOrTickerToFractionalDigits(isLbtc ? lbtcUnit ?? '' : '', precision);
+    return removeInsignificant(
+      new Big(sats)
+        .div(new Big(10).pow(new Big(precision).minus(unitToExponent(unit)).toNumber()))
+        .toFixed(decimalPlaces)
+    );
   } catch (err) {
     console.error(err);
     return 'N/A';
@@ -54,9 +57,13 @@ export function fromSatsToUnitOrFractional(
  * @param lbtcUnitTo
  */
 export function fromUnitToUnit(amount: number, lbtcUnitFrom: LbtcUnit, lbtcUnitTo: LbtcUnit): string {
-  return new Big(amount)
-    .div(new Big(10).pow(new Big(unitToExponent(lbtcUnitFrom)).minus(unitToExponent(lbtcUnitTo)).toNumber()))
-    .toFixed();
+  return removeInsignificant(
+    new Big(amount)
+      .div(
+        new Big(10).pow(new Big(unitToExponent(lbtcUnitFrom)).minus(unitToExponent(lbtcUnitTo)).toNumber())
+      )
+      .toFixed(lbtcUnitOrTickerToFractionalDigits(lbtcUnitTo, 8))
+  );
 }
 
 /**

--- a/src/utils/unitConvert.ts
+++ b/src/utils/unitConvert.ts
@@ -37,11 +37,23 @@ export function fromSatsToUnitOrFractional(
     const unit = isLbtc ? lbtcUnit : undefined;
     return new Big(sats)
       .div(new Big(10).pow(new Big(precision).minus(unitToExponent(unit)).toNumber()))
-      .toString();
+      .toFixed();
   } catch (err) {
     console.error(err);
     return 'N/A';
   }
+}
+
+/**
+ * Takes liquid bitcoin amount in certain unit and convert it to another unit
+ * @param amount
+ * @param lbtcUnitFrom
+ * @param lbtcUnitTo
+ */
+export function fromUnitToUnit(amount: number, lbtcUnitFrom: LbtcUnit, lbtcUnitTo: LbtcUnit): string {
+  return new Big(amount)
+    .div(new Big(10).pow(new Big(unitToExponent(lbtcUnitFrom)).minus(unitToExponent(lbtcUnitTo)).toNumber()))
+    .toFixed();
 }
 
 /**

--- a/src/utils/unitConvert.ts
+++ b/src/utils/unitConvert.ts
@@ -57,6 +57,11 @@ export function fromSatsToUnitOrFractional(
  * @param lbtcUnitTo
  */
 export function fromUnitToUnit(amount: number, lbtcUnitFrom: LbtcUnit, lbtcUnitTo: LbtcUnit): string {
+  const amountStr = removeInsignificant(new Big(amount).toFixed());
+  const decimalPlaces = amountStr.includes('.') ? amountStr.split('.')[1].length : 0;
+  if (decimalPlaces > lbtcUnitOrTickerToFractionalDigits(lbtcUnitFrom, 8)) {
+    throw new Error('Invalid amount: too many decimal places');
+  }
   return removeInsignificant(
     new Big(amount)
       .div(

--- a/src/utils/unitConvert.ts
+++ b/src/utils/unitConvert.ts
@@ -58,7 +58,7 @@ export function fromSatsToUnitOrFractional(
  * @param lbtcUnitTo
  */
 export function fromUnitToUnit(amount: number, lbtcUnitFrom: LbtcUnit, lbtcUnitTo: LbtcUnit): string {
-  const amountStr = removeInsignificant(new Big(amount).toFixed());
+  const amountStr = new Big(amount).toFixed();
   const decimalPlaces = amountStr.includes('.') ? amountStr.split('.')[1].length : 0;
   if (decimalPlaces > lbtcUnitOrTickerToFractionalDigits(lbtcUnitFrom, 8)) {
     throw new Error('Invalid amount: too many decimal places');


### PR DESCRIPTION
It closes #299 
- `fromUnitToUnit` takes liquid bitcoin amount in certain unit and convert it to another unit
- use `toFixed()` instead of `toString()` to avoid scientific notation
- throw if amount is invalid

Please review @tiero 