### PR TITLE
Kill previous dev server process at start

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,8 @@
 {
   "build": {
     "beforeBuildCommand": "yarn build",
-    "beforeDevCommand": "yarn start",
+    "//": "https://github.com/tauri-apps/tauri/issues/2794",
+    "beforeDevCommand": "kill -9 $(lsof -i :3003 -t) &>/dev/null || true && yarn start",
     "devPath": "http://localhost:3003",
     "distDir": "../build"
   },


### PR DESCRIPTION
Tauri launched with `yarn tauri:dev` doesn't kill dev server process.
This PR kills the previous dev server process at startup. Not ideal solution but it works. If no process is running on 3003 then the error is ignored.
 
Better solution would have been to kill the process when quitting. I tried this from Rust `Command::new("kill -9 $(lsof -i :3003 -t)");` but has no effect.

Please review @tiero 
