### PR TITLE
Remove baseUrl from config file

### DIFF
--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -8,7 +8,6 @@ let config: {
   explorerBitcoinAPI: string;
   explorerLiquidUI: string;
   explorerBitcoinUI: string;
-  tdexdBaseUrl: string;
 };
 
 export const configProduction: typeof config = {
@@ -17,7 +16,6 @@ export const configProduction: typeof config = {
   explorerBitcoinAPI: 'https://blockstream.info/api',
   explorerLiquidUI: 'https://blockstream.info/liquid',
   explorerBitcoinUI: 'https://blockstream.info',
-  tdexdBaseUrl: 'https://localhost:9000',
 };
 
 export const configTestnet: typeof config = {
@@ -26,7 +24,6 @@ export const configTestnet: typeof config = {
   explorerBitcoinAPI: 'https://blockstream.info/testnet/api',
   explorerLiquidUI: 'https://blockstream.info/liquidtestnet',
   explorerBitcoinUI: 'https://blockstream.info/testnet',
-  tdexdBaseUrl: 'https://localhost:9000',
 };
 
 export const configRegtest: typeof config = {
@@ -35,7 +32,6 @@ export const configRegtest: typeof config = {
   explorerBitcoinAPI: 'http://localhost:3000',
   explorerLiquidUI: 'http://localhost:5001',
   explorerBitcoinUI: 'http://localhost:5000',
-  tdexdBaseUrl: 'https://localhost:9000',
 };
 
 export const configRecord: Record<NetworkString, typeof config> = {

--- a/src/common/UserMenu/index.tsx
+++ b/src/common/UserMenu/index.tsx
@@ -8,10 +8,8 @@ import type { RootState } from '../../app/store';
 import { useTypedDispatch, useTypedSelector } from '../../app/store';
 import { ReactComponent as chevronRight } from '../../assets/images/chevron-right.svg';
 import { liquidApi } from '../../features/liquid.api';
-import { operatorApi } from '../../features/operator/operator.api';
 import { disconnectProxy, logout, resetSettings } from '../../features/settings/settingsSlice';
-import { walletApi } from '../../features/wallet/wallet.api';
-import { walletUnlockerApi } from '../../features/walletUnlocker/walletUnlocker.api';
+import { tdexApi } from '../../features/tdex.api';
 import { ONBOARDING_PAIRING_ROUTE, SETTINGS_ROUTE } from '../../routes/constants';
 
 interface UserMenuProps {
@@ -35,9 +33,7 @@ export const UserMenu = ({ isUserMenuVisible }: UserMenuProps): JSX.Element => {
     dispatch(logout());
     // Reset the APIs state completely
     dispatch(liquidApi.util.resetApiState());
-    dispatch(operatorApi.util.resetApiState());
-    dispatch(walletUnlockerApi.util.resetApiState());
-    dispatch(walletApi.util.resetApiState());
+    dispatch(tdexApi.util.resetApiState());
     navigate(ONBOARDING_PAIRING_ROUTE);
   };
 
@@ -53,9 +49,7 @@ export const UserMenu = ({ isUserMenuVisible }: UserMenuProps): JSX.Element => {
     dispatch(resetSettings());
     // Reset the APIs state completely
     dispatch(liquidApi.util.resetApiState());
-    dispatch(operatorApi.util.resetApiState());
-    dispatch(walletUnlockerApi.util.resetApiState());
-    dispatch(walletApi.util.resetApiState());
+    dispatch(tdexApi.util.resetApiState());
     navigate(ONBOARDING_PAIRING_ROUTE);
   };
 

--- a/src/features/settings/settingsSlice.ts
+++ b/src/features/settings/settingsSlice.ts
@@ -121,7 +121,7 @@ export const initialState: SettingsState = {
     'https://blockstream.info/liquid',
   ],
   explorerLiquidUI: config.explorerLiquidUI,
-  baseUrl: USE_PROXY ? PROXY_URL : config.tdexdBaseUrl,
+  baseUrl: USE_PROXY ? PROXY_URL : '',
   assets: {
     liquid: featuredAssets['liquid'],
     testnet: featuredAssets['testnet'],
@@ -190,6 +190,7 @@ export const settingsSlice = createSlice({
     logout: (state) => {
       state.macaroonCredentials = undefined;
       state.tdexdConnectUrl = undefined;
+      state.baseUrl = '';
     },
     resetSettings: () => initialState,
   },


### PR DESCRIPTION
- Remove baseUrl from config file because this value should only be taken from PROXY_URL or extracted from tdexConnectUrl. We can't have a default value.

- reset all apis using the base api `tdexApi`
