### PR TITLE
Calculate total earned percentage change

### DIFF
--- a/src/assets/styles/button.less
+++ b/src/assets/styles/button.less
@@ -44,7 +44,6 @@ a.ant-btn {
 
     &:focus {
       color: #27cb1f;
-      background: transparent;
       box-shadow: none;
     }
   }

--- a/src/features/home/DashboardPanelLeft.tsx
+++ b/src/features/home/DashboardPanelLeft.tsx
@@ -1,6 +1,7 @@
 import './dashboardPanelLeft.less';
 import { PlusCircleOutlined } from '@ant-design/icons';
 import { Button, Col, Divider, Row, Typography } from 'antd';
+import classNames from 'classnames';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -11,7 +12,11 @@ import { useTypedSelector } from '../../app/store';
 import { CREATE_MARKET_ROUTE } from '../../routes/constants';
 import type { LbtcUnit } from '../../utils';
 import { LBTC_ASSET, fromUnitToUnit } from '../../utils';
-import { useListMarketsQuery, useTotalCollectedSwapFeesQuery } from '../operator/operator.api';
+import {
+  useListMarketsQuery,
+  useTotalCollectedSwapFeesChangeQuery,
+  useTotalCollectedSwapFeesQuery,
+} from '../operator/operator.api';
 import type { PriceFeedQueryResult } from '../rates.api';
 import { convertAmountToFavoriteCurrency } from '../rates.api';
 
@@ -38,6 +43,10 @@ export const DashboardPanelLeft = ({
   const pausedMarkets = (listMarkets?.marketsList.length ?? 0) - activeMarkets;
   const markets = listMarkets?.marketsList.map((m) => m.market as Market.AsObject);
   const { data: totalCollectedSwapFeesSats } = useTotalCollectedSwapFeesQuery({
+    markets: markets,
+    prices: prices,
+  });
+  const { data: totalCollectedSwapFeesChange } = useTotalCollectedSwapFeesChangeQuery({
     markets: markets,
     prices: prices,
   });
@@ -95,9 +104,18 @@ export const DashboardPanelLeft = ({
             <span className="dm-sans dm-sans__xxxx ml-3">{lbtcUnit}</span>
           )}
         </Col>
-        <Col className="total-earned-change" span={8}>
+        <Col
+          className={classNames('total-earned-change', {
+            'total-earned-change__is-negative': totalCollectedSwapFeesChange?.charAt(0) === '-',
+          })}
+          span={8}
+        >
           <div>24h</div>
-          <div>+2.85%</div>
+          {totalCollectedSwapFeesChange === 'N/A' ? (
+            <div>N/A</div>
+          ) : (
+            <div>{totalCollectedSwapFeesChange}%</div>
+          )}
         </Col>
       </Row>
       <Divider style={{ margin: '12px 0 40px 0' }} />

--- a/src/features/home/dashboardPanelLeft.less
+++ b/src/features/home/dashboardPanelLeft.less
@@ -17,6 +17,11 @@
       font-weight: 500;
       line-height: 12px;
     }
+    &.total-earned-change__is-negative {
+      div:nth-child(2) {
+        color: @error-color;
+      }
+    }
   }
   .create-new-btn {
     padding: 20px;

--- a/src/features/operator/operator.api.ts
+++ b/src/features/operator/operator.api.ts
@@ -846,7 +846,7 @@ export const operatorApi = tdexApi.injectEndpoints({
           });
           // Calculate timeranges
           const milliseconds24hrs = 24 * 60 * 60 * 1000;
-          const startDate = new Date('2022-01-01T00:00:00').toISOString();
+          const startDate = new Date(`${new Date().getFullYear()}-01-01T00:00:00`).toISOString();
           const minus24hDate = new Date(Date.now() - milliseconds24hrs).toISOString();
           const timeRangeUntil24hAgo = new TimeRange();
           const customPeriodUntil24hAgo = new CustomPeriod();


### PR DESCRIPTION
It closes #276 

- Request getMarketReport from start date `${new Date().getFullYear()}-01-01T00:00:00` until 24h ago 
- Request getMarketReport from start date `${new Date().getFullYear()}-01-01T00:00:00` until now
- For each report, convert baseAmount and quoteAmount to LBTC L-sats, then add them together.
- Finally we calculate percentage variation by doing `((totalCollectedSwapFeesUntilNow - totalCollectedSwapFeesUntil24hAgo) / totalCollectedSwapFeesUntil24hAgo) * 100`

Please review @tiero 