### PR TITLE
Add isTauri in store

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import { sleep } from './utils';
 
 export const App = (): JSX.Element => {
   const dispatch = useTypedDispatch();
-  const { useProxy, proxyHealth, proxyPid, tdexdConnectUrl } = useTypedSelector(
+  const { useProxy, isTauri, proxyHealth, proxyPid, tdexdConnectUrl } = useTypedSelector(
     ({ settings }: RootState) => settings
   );
   const [isServiceUnavailableModalVisible, setIsServiceUnavailableModalVisible] = useState<boolean>(false);
@@ -41,7 +41,7 @@ export const App = (): JSX.Element => {
         }
       });
 
-      if (useProxy) {
+      if (useProxy && isTauri) {
         // Register close app event for cleanup
         await once('quit-event', async () => {
           try {
@@ -90,8 +90,9 @@ export const App = (): JSX.Element => {
 
   const startAndConnectToProxy = useCallback(async () => {
     if (useProxy && proxyHealth !== 'SERVING' && !isExiting) {
-      // Start proxy
-      await startProxy();
+      if (isTauri) {
+        await startProxy();
+      }
       // Health check
       const { desc } = await dispatch(healthCheckProxy()).unwrap();
       if (desc === 'SERVING_NOT_CONNECTED') {
@@ -111,7 +112,7 @@ export const App = (): JSX.Element => {
         console.error('gRPC Proxy:', desc);
       }
     }
-  }, [useProxy, proxyHealth, isExiting, startProxy, dispatch, tdexdConnectUrl]);
+  }, [useProxy, proxyHealth, isExiting, isTauri, dispatch, startProxy, tdexdConnectUrl]);
 
   // Update health proxy status every x seconds
   // Try to restart proxy if 'Load failed' error

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ export const App = (): JSX.Element => {
         }
       });
 
-      if (useProxy && isTauri) {
+      if (isTauri) {
         // Register close app event for cleanup
         await once('quit-event', async () => {
           try {

--- a/src/features/settings/settingsSlice.ts
+++ b/src/features/settings/settingsSlice.ts
@@ -30,6 +30,7 @@ export interface SettingsState {
   assets: Record<NetworkString, Asset[]>;
   baseUrl: string;
   useProxy: boolean;
+  isTauri: boolean;
   marketsLabelled?: MarketLabelled[];
   macaroonCredentials?: string;
   tdexdConnectUrl?: string;
@@ -122,6 +123,7 @@ export const initialState: SettingsState = {
   ],
   explorerLiquidUI: config.explorerLiquidUI,
   baseUrl: USE_PROXY ? PROXY_URL : '',
+  isTauri: '__TAURI__' in window,
   assets: {
     liquid: featuredAssets['liquid'],
     testnet: featuredAssets['testnet'],

--- a/src/features/walletUnlocker/OnboardingPairing.tsx
+++ b/src/features/walletUnlocker/OnboardingPairing.tsx
@@ -26,7 +26,7 @@ export const OnboardingPairing = (): JSX.Element => {
   const [isDownloadCertModalVisible, setIsDownloadCertModalVisible] = useState<boolean>(false);
   const navigate = useNavigate();
   const dispatch = useTypedDispatch();
-  const { useProxy } = useTypedSelector(({ settings }) => settings);
+  const { useProxy, isTauri } = useTypedSelector(({ settings }) => settings);
 
   useEffect(() => {
     // Reset the APIs state completely
@@ -111,7 +111,7 @@ export const OnboardingPairing = (): JSX.Element => {
                   className="overflow-hidden"
                   placeholder="Paste the Tdex daemon connect URL"
                   onPaste={(ev) => {
-                    if (!(window as any).__TAURI__ && !(window as any).USE_PROXY) {
+                    if (!isTauri && !useProxy) {
                       showDownloadCertModal();
                     } else {
                       const connectString = ev.clipboardData.getData('text');


### PR DESCRIPTION
Add `isTauri` in store and do not assume `isTauri` === `useProxy`.

To run the proxy in browser mode `window.USE_PROXY` needs to be set to true.

Blocker: `error connection refused`. Probably because proxy and daemon are not running in the same container. 