### PR TITLE
Fix "expected 1 macaroon, got 0" error on Tauri

### DIFF
--- a/src/features/settings/settingsSlice.ts
+++ b/src/features/settings/settingsSlice.ts
@@ -203,7 +203,7 @@ export function selectBaseUrl(state: RootState): string {
 }
 
 export function selectMacaroonCreds(state: RootState): Metadata | null {
-  if (!state.settings.useProxy && state.settings.macaroonCredentials) {
+  if (state.settings.macaroonCredentials) {
     return {
       macaroon: state.settings.macaroonCredentials,
     };


### PR DESCRIPTION
Allow retrieving macaroon on Tauri.

Please review @tiero 