### PR TITLE
Fix `expected 1 macaroon, got 2` on Tauri

### DIFF
--- a/src/features/settings/settingsSlice.ts
+++ b/src/features/settings/settingsSlice.ts
@@ -204,7 +204,7 @@ export function selectBaseUrl(state: RootState): string {
 }
 
 export function selectMacaroonCreds(state: RootState): Metadata | null {
-  if (state.settings.macaroonCredentials) {
+  if (!state.settings.useProxy && state.settings.macaroonCredentials) {
     return {
       macaroon: state.settings.macaroonCredentials,
     };


### PR DESCRIPTION
Reverting https://github.com/tdex-network/tdex-dashboard/pull/389
Calling `await client.listMarkets(new ListMarketsRequest(), metadata)` with metadata `null` works.
Calling `await client.listMarkets(new ListMarketsRequest(), metadata)` with metadata `macaroon: xxx` we get `expected 1 macaroon, got 2`