### PR TITLE
Display error "Too many decimals"

### DIFF
--- a/src/features/operator/Market/MarketSettings/UpdateMarketPriceForm.tsx
+++ b/src/features/operator/Market/MarketSettings/UpdateMarketPriceForm.tsx
@@ -59,6 +59,9 @@ export const UpdateMarketPriceForm = ({
         if (typeof err === 'string') {
           notification.error({ message: err, key: 'onUpdateMarketFinish error' });
         }
+        if (err instanceof Error) {
+          notification.error({ message: err.message, key: 'onUpdateMarketFinish error' });
+        }
       }
     }
   };


### PR DESCRIPTION
In UpdateMarketPrice form btc input, the number of decimals depends on the unit. 
L-BTC == 8 decimals
L-mBTC == 5 decimals
L-bits == 3 decimals
L-sats == 0 decimals

Display error "Too many decimals" if error