### PR TITLE
Fix proxy connection after wallet initialization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -145,7 +145,7 @@ export const App = (): JSX.Element => {
         }
       })();
     }
-  }, [isExiting, proxyHealth, startProxy, useProxy]);
+  }, [isExiting, proxyHealth, startupProxy, useProxy]);
 
   useEffect(() => {
     if (useProxy) {
@@ -160,7 +160,7 @@ export const App = (): JSX.Element => {
         }
       })();
     }
-  }, [useProxy, tdexdConnectUrl]);
+  }, [useProxy, tdexdConnectUrl, dispatch]);
 
   return (
     <>

--- a/src/common/UserMenu/index.tsx
+++ b/src/common/UserMenu/index.tsx
@@ -10,7 +10,7 @@ import { useTypedDispatch, useTypedSelector } from '../../app/store';
 import { liquidApi } from '../../features/liquid.api';
 import { DefaultCurrencyRadioButtons } from '../../features/settings/DefaultCurrencyRadioButtons';
 import { FavoriteBitcoinUnitsRadioButtons } from '../../features/settings/FavoriteBitcoinUnitsRadioButtons';
-import { disconnectProxy, logout, resetSettings } from '../../features/settings/settingsSlice';
+import { logout, resetSettings } from '../../features/settings/settingsSlice';
 import { tdexApi } from '../../features/tdex.api';
 import { ONBOARDING_PAIRING_ROUTE, SETTINGS_ROUTE } from '../../routes/constants';
 
@@ -35,14 +35,6 @@ export const UserMenu = ({ isUserMenuVisible }: UserMenuProps): JSX.Element => {
   };
 
   const clearCache = async () => {
-    if (useProxy) {
-      try {
-        // Close proxy connection to avoid conflict
-        await dispatch(disconnectProxy()).unwrap();
-      } catch (err) {
-        console.error(err);
-      }
-    }
     dispatch(resetSettings());
     // Reset the APIs state completely
     dispatch(liquidApi.util.resetApiState());

--- a/src/common/UserMenu/index.tsx
+++ b/src/common/UserMenu/index.tsx
@@ -27,14 +27,6 @@ export const UserMenu = ({ isUserMenuVisible }: UserMenuProps): JSX.Element => {
   const [isDisconnectAndResetModalVisible, setIsDisconnectAndResetModalVisible] = useState<boolean>(false);
 
   const logOut = async () => {
-    if (useProxy) {
-      try {
-        // Close proxy connection to avoid conflict
-        await dispatch(disconnectProxy()).unwrap();
-      } catch (err) {
-        console.error(err);
-      }
-    }
     dispatch(logout());
     // Reset the APIs state completely
     dispatch(liquidApi.util.resetApiState());

--- a/src/common/UserMenu/index.tsx
+++ b/src/common/UserMenu/index.tsx
@@ -5,8 +5,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import './userMenu.less';
-import type { RootState } from '../../app/store';
-import { useTypedDispatch, useTypedSelector } from '../../app/store';
+import { useTypedDispatch } from '../../app/store';
 import { liquidApi } from '../../features/liquid.api';
 import { DefaultCurrencyRadioButtons } from '../../features/settings/DefaultCurrencyRadioButtons';
 import { FavoriteBitcoinUnitsRadioButtons } from '../../features/settings/FavoriteBitcoinUnitsRadioButtons';
@@ -23,7 +22,6 @@ interface UserMenuProps {
 export const UserMenu = ({ isUserMenuVisible }: UserMenuProps): JSX.Element => {
   const dispatch = useTypedDispatch();
   const navigate = useNavigate();
-  const useProxy = useTypedSelector(({ settings }: RootState) => settings.useProxy);
   const [isDisconnectAndResetModalVisible, setIsDisconnectAndResetModalVisible] = useState<boolean>(false);
 
   const logOut = async () => {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -18,7 +18,6 @@ import { MarketWithdraw } from '../features/operator/Market/MarketWithdraw';
 import { useGetInfoQuery } from '../features/operator/operator.api';
 import { Settings } from '../features/settings/Settings';
 import {
-  disconnectProxy,
   logout,
   setExplorerLiquidAPI,
   setExplorerLiquidUI,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -96,9 +96,6 @@ export const Routes = (): JSX.Element => {
           key: 'service unavailable',
         });
         dispatch(logout());
-        if (useProxy) {
-          await dispatch(disconnectProxy()).unwrap();
-        }
       }
     })();
   }, [dispatch, isReadyError, navigate, useProxy]);


### PR DESCRIPTION
This fixes the connection of the proxy to the daemon after wallet initialization.
For this, the original effect in App.tsx starting and passing the connect URL to the proxy (via /connect endpoint) has been split into 2 different ones: 1 for starting up the proxy, and 1 for handling the connection based entirely on changes to `tdexdConnectUrl`.

By doing so, every time the connect URL changes in the store, ie. after creating/restoring a wallet, the dashboard provides to pass it down to the proxy. In case the connect URL is removed from the store (ie. logout), the dashboard takes care of calling proxy's `/disconnect` endpoint.

We now have a single point in the codebase where we handle the connection to the proxy.

Closes #405.

Please @tiero @Janaka-Steph review.