### PR TITLE
If mnemonic invalid show toast error but keep the phrase in input

### DIFF
--- a/src/features/walletUnlocker/OnboardingConfirmMnemonic.tsx
+++ b/src/features/walletUnlocker/OnboardingConfirmMnemonic.tsx
@@ -39,7 +39,7 @@ export const OnboardingConfirmMnemonic = (): JSX.Element => {
   const { state } = useLocation() as { state: { mnemonic: string[]; password: string } };
   const tdexdConnectUrl = useTypedSelector(({ settings }) => settings.tdexdConnectUrl);
   const mnemonicRandomized = shuffleMnemonic([...state.mnemonic]);
-  const [wordsList, setWordsList] = useState<string[]>(mnemonicRandomized);
+  const [wordsList] = useState<string[]>(mnemonicRandomized);
   const [selectedWordIndexes, setSelectedWordIndexes] = useState<number[]>([]);
   const [error, setError] = useState(NULL_ERROR);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -86,8 +86,7 @@ export const OnboardingConfirmMnemonic = (): JSX.Element => {
     } else {
       setIsLoading(false);
       setError(ERROR_MSG);
-      setSelectedWordIndexes([]);
-      setWordsList(mnemonicRandomized);
+      notification.error({ message: ERROR_MSG, key: ERROR_MSG });
     }
   };
 
@@ -163,7 +162,6 @@ export const OnboardingConfirmMnemonic = (): JSX.Element => {
                 </Button>
               ))}
             </div>
-            <div className="error">{error}</div>
           </Space>
           <Row>
             <Col span={8} offset={8}>


### PR DESCRIPTION
If mnemonic is invalid show toast error but keep the phrase in input. Idea is to avoid redoing every word if the mistake was at the end.

Please review @tiero 