### PR TITLE
Fix packaged mode to alwyas assume /api as path for daemon APIs

### DIFF
--- a/src/features/settings/settingsSlice.ts
+++ b/src/features/settings/settingsSlice.ts
@@ -113,7 +113,7 @@ export const getTdexdConnectUrl = createAsyncThunk<string, string, { state: Root
   async (password, thunkAPI) => {
     try {
       if (!(window as any).IS_PACKAGED) throw new Error('App is not in packaged mode');
-      const res = await fetch(`${window.location.host}/tdexdconnect`, {
+      const res = await fetch(`${window.location.protocol}//${window.location.host}/api/tdexdconnect`, {
         method: 'GET',
         headers: new Headers({
           Authorization: `Basic ${Buffer.from(`tdex:${password}`).toString('base64')}`,

--- a/src/features/walletUnlocker/OnboardingPairing.tsx
+++ b/src/features/walletUnlocker/OnboardingPairing.tsx
@@ -66,7 +66,7 @@ export const OnboardingPairing = (): JSX.Element => {
       if ((window as any).IS_PACKAGED) {
         // isPackaged is false on first load, set it to true
         dispatch(setIsPackaged(true));
-        dispatch(setBaseUrl(window.location.host));
+        dispatch(setBaseUrl(`${window.location.protocol}//${window.location.host}/api`));
         const isReady = await dispatch(walletUnlockerApi.endpoints.isReady.initiate());
         // If connection to daemon fails, switch to regular pairing and show toast error message
         if (isReady.error) {


### PR DESCRIPTION
Before this commit, there was no way the app could reach the backend daemon APIs without fixing a pathname that the [reverse proxy ](https://github.com/tdex-network/umbrel-apps/blob/tdex/tdex/caddy-data/Caddyfile) would have used.

Please @Janaka-Steph  review
