### PR TITLE
Display Market balance and price on mobile

### DIFF
--- a/src/features/operator/Market/MarketOverview/BalanceAndPrice.tsx
+++ b/src/features/operator/Market/MarketOverview/BalanceAndPrice.tsx
@@ -1,0 +1,64 @@
+import { Col, Grid, Row } from 'antd';
+import classNames from 'classnames';
+
+import type { MarketInfo } from '../../../../api-spec/protobuf/gen/js/tdex-daemon/v1/types_pb';
+import { CurrencyIcon } from '../../../../common/CurrencyIcon';
+import type { Asset } from '../../../../domain/asset';
+import type { NetworkString } from '../../../../domain/misc';
+import type { LbtcUnit } from '../../../../utils';
+import { formatCompact, isLbtcAssetId, unitToExponent } from '../../../../utils';
+
+const { useBreakpoint } = Grid;
+
+interface BalanceAndPriceProps {
+  baseAsset: Asset;
+  quoteAsset: Asset;
+  baseAmount?: string;
+  quoteAmount?: string;
+  marketInfo?: MarketInfo;
+  network: NetworkString;
+  lbtcUnit: LbtcUnit;
+}
+
+export const BalanceAndPrice = ({
+  baseAsset,
+  quoteAsset,
+  marketInfo,
+  lbtcUnit,
+  network,
+  baseAmount,
+  quoteAmount,
+}: BalanceAndPriceProps): JSX.Element => {
+  const screens = useBreakpoint();
+  return (
+    <Row className={classNames({ 'mb-2': !screens.xs })}>
+      <Col xs={24} sm={marketInfo?.strategyType === 0 ? 16 : 24} className="d-flex align-center">
+        <div className="d-flex align-center">
+          <CurrencyIcon assetId={baseAsset?.asset_id} />
+          <span className="dm-mono dm-mono__x dm_mono__bold mx-2">
+            {isLbtcAssetId(baseAsset?.asset_id, network) ? lbtcUnit : baseAsset?.ticker}
+          </span>
+          <span className="dm-mono dm-mono__xx mr-6">{baseAmount}</span>
+        </div>
+        <div className="d-flex align-center">
+          <CurrencyIcon assetId={quoteAsset?.asset_id} />
+          <span className="dm-mono dm-mono__x dm_mono__bold mx-2">
+            {isLbtcAssetId(quoteAsset?.asset_id, network) ? lbtcUnit : quoteAsset?.ticker}
+          </span>
+          <span className="dm-mono dm-mono__xx">{quoteAmount}</span>
+        </div>
+      </Col>
+      <Col
+        xs={marketInfo?.strategyType === 0 ? 24 : 0}
+        sm={marketInfo?.strategyType === 0 ? 8 : 0}
+        className={classNames({ 'text-end': !screens.xs, 'mt-2': screens.xs })}
+      >
+        <span className="dm-mono dm-mono__x dm_mono__bold mx-2">{`${formatCompact(
+          (marketInfo?.price?.quotePrice ?? 0) * Math.pow(10, -unitToExponent(lbtcUnit))
+        )} ${isLbtcAssetId(quoteAsset?.asset_id, network) ? lbtcUnit : quoteAsset?.ticker} for 1 ${
+          isLbtcAssetId(baseAsset?.asset_id, network) ? lbtcUnit : baseAsset?.ticker
+        }`}</span>
+      </Col>
+    </Row>
+  );
+};

--- a/src/features/operator/Market/MarketOverview/BalanceAndPriceMobile.tsx
+++ b/src/features/operator/Market/MarketOverview/BalanceAndPriceMobile.tsx
@@ -42,21 +42,21 @@ export const BalanceAndPriceMobile = ({
           </Col>
         </Row>
         <Row align="middle" className="mt-1">
-          <Col className="d-flex align-center">
-            <div className="d-flex align-center">
+          <Col span={24}>
+            <Col span={24} className="d-flex align-center">
               <CurrencyIcon assetId={baseAsset?.asset_id} />
               <span className="dm-mono dm-mono__x dm_mono__bold mx-2">
                 {isLbtcAssetId(baseAsset?.asset_id, network) ? lbtcUnit : baseAsset?.ticker}
               </span>
               <span className="dm-mono dm-mono__xx mr-6">{baseAmount}</span>
-            </div>
-            <div className="d-flex align-center">
+            </Col>
+            <Col span={24} className="d-flex align-center mt-2">
               <CurrencyIcon assetId={quoteAsset?.asset_id} />
               <span className="dm-mono dm-mono__x dm_mono__bold mx-2">
                 {isLbtcAssetId(quoteAsset?.asset_id, network) ? lbtcUnit : quoteAsset?.ticker}
               </span>
               <span className="dm-mono dm-mono__xx">{quoteAmount}</span>
-            </div>
+            </Col>
           </Col>
         </Row>
       </div>

--- a/src/features/operator/Market/MarketOverview/BalanceAndPriceMobile.tsx
+++ b/src/features/operator/Market/MarketOverview/BalanceAndPriceMobile.tsx
@@ -1,0 +1,84 @@
+import { InfoCircleOutlined } from '@ant-design/icons';
+import { Col, Row, Typography } from 'antd';
+import React from 'react';
+
+import type { MarketInfo } from '../../../../api-spec/protobuf/gen/js/tdex-daemon/v1/types_pb';
+import { CurrencyIcon } from '../../../../common/CurrencyIcon';
+import type { Asset } from '../../../../domain/asset';
+import type { NetworkString } from '../../../../domain/misc';
+import type { LbtcUnit } from '../../../../utils';
+import { formatCompact, isLbtcAssetId, unitToExponent } from '../../../../utils';
+
+const { Title } = Typography;
+
+interface BalanceAndPriceMobileProps {
+  baseAsset: Asset;
+  quoteAsset: Asset;
+  baseAmount?: string;
+  quoteAmount?: string;
+  marketInfo?: MarketInfo;
+  network: NetworkString;
+  lbtcUnit: LbtcUnit;
+}
+
+export const BalanceAndPriceMobile = ({
+  baseAsset,
+  quoteAsset,
+  marketInfo,
+  lbtcUnit,
+  network,
+  baseAmount,
+  quoteAmount,
+}: BalanceAndPriceMobileProps): JSX.Element => {
+  return (
+    <Col span={24}>
+      <div className="panel panel__grey mt-4">
+        <Row>
+          <Col span={24}>
+            <Title className="dm-sans dm-sans__x dm-sans__bold dm-sans__grey d-inline mr-4" level={3}>
+              Market Balance
+            </Title>
+            <InfoCircleOutlined className="grey" />
+          </Col>
+        </Row>
+        <Row align="middle" className="mt-1">
+          <Col className="d-flex align-center">
+            <div className="d-flex align-center">
+              <CurrencyIcon assetId={baseAsset?.asset_id} />
+              <span className="dm-mono dm-mono__x dm_mono__bold mx-2">
+                {isLbtcAssetId(baseAsset?.asset_id, network) ? lbtcUnit : baseAsset?.ticker}
+              </span>
+              <span className="dm-mono dm-mono__xx mr-6">{baseAmount}</span>
+            </div>
+            <div className="d-flex align-center">
+              <CurrencyIcon assetId={quoteAsset?.asset_id} />
+              <span className="dm-mono dm-mono__x dm_mono__bold mx-2">
+                {isLbtcAssetId(quoteAsset?.asset_id, network) ? lbtcUnit : quoteAsset?.ticker}
+              </span>
+              <span className="dm-mono dm-mono__xx">{quoteAmount}</span>
+            </div>
+          </Col>
+        </Row>
+      </div>
+      <div className="panel panel__grey mt-4">
+        <Row>
+          <Col span={24}>
+            <Title className="dm-sans dm-sans__x dm-sans__bold dm-sans__grey d-inline mr-4" level={3}>
+              Price
+            </Title>
+            <InfoCircleOutlined className="grey" />
+          </Col>
+        </Row>
+        <Row align="middle">
+          <Col className="d-flex align-center">
+            <span className="dm-mono dm-mono__x dm_mono__bold">{`${formatCompact(
+              (marketInfo?.price?.quotePrice ?? 0) * Math.pow(10, -unitToExponent(lbtcUnit))
+            )} ${isLbtcAssetId(quoteAsset?.asset_id, network) ? lbtcUnit : quoteAsset?.ticker} for 1 ${
+              isLbtcAssetId(baseAsset?.asset_id, network) ? lbtcUnit : baseAsset?.ticker
+            }`}</span>
+          </Col>
+        </Row>
+      </div>
+    </Col>
+  );
+};

--- a/src/features/operator/Market/MarketOverview/CollectedSwapFees.tsx
+++ b/src/features/operator/Market/MarketOverview/CollectedSwapFees.tsx
@@ -1,0 +1,58 @@
+import { InfoCircleOutlined } from '@ant-design/icons';
+import { Col, Row, Typography } from 'antd';
+import React from 'react';
+
+import type { MarketReport } from '../../../../api-spec/protobuf/gen/js/tdex-daemon/v1/types_pb';
+import { useTypedSelector } from '../../../../app/store';
+import type { Asset } from '../../../../domain/asset';
+import { fromSatsToUnitOrFractional, isLbtcTicker } from '../../../../utils';
+
+const { Title } = Typography;
+
+interface CollectedSwapFeesProps {
+  marketReport?: MarketReport;
+  state: { baseAsset: Asset; quoteAsset: Asset };
+}
+
+export const CollectedSwapFees = ({ marketReport, state }: CollectedSwapFeesProps): JSX.Element => {
+  const lbtcUnit = useTypedSelector(({ settings }) => settings.lbtcUnit);
+
+  return (
+    <div className="panel panel__grey mb-4">
+      <Row>
+        <Col span={24}>
+          <Title className="dm-sans dm-sans__x dm-sans__bold dm-sans__grey d-inline mr-4" level={3}>
+            Collected Swap Fees
+          </Title>
+          <InfoCircleOutlined className="grey" />
+        </Col>
+      </Row>
+      <Row align="middle">
+        <Col>
+          <div>
+            <span className="dm-mono dm-mono__xx">
+              {fromSatsToUnitOrFractional(
+                marketReport?.totalCollectedFees?.baseAmount ?? 0,
+                state?.baseAsset?.precision,
+                isLbtcTicker(state?.baseAsset?.ticker),
+                lbtcUnit
+              )}
+            </span>
+            <span className="dm-sans dm-sans__x ml-2">{state?.baseAsset?.formattedTicker ?? ''}</span>
+          </div>
+          <div>
+            <span className="dm-mono dm-mono__xx">
+              {fromSatsToUnitOrFractional(
+                marketReport?.totalCollectedFees?.quoteAmount ?? 0,
+                state?.quoteAsset?.precision,
+                isLbtcTicker(state?.quoteAsset?.ticker),
+                lbtcUnit
+              )}
+            </span>
+            <span className="dm-sans dm-sans__x ml-2">{state?.quoteAsset?.formattedTicker ?? ''}</span>
+          </div>
+        </Col>
+      </Row>
+    </div>
+  );
+};

--- a/src/features/operator/Market/MarketOverview/VolumePanel.tsx
+++ b/src/features/operator/Market/MarketOverview/VolumePanel.tsx
@@ -1,26 +1,15 @@
-import { Col, Row, Typography, Radio } from 'antd';
+import { Typography, Radio } from 'antd';
 import type { Dispatch, SetStateAction } from 'react';
-import React, { useEffect, useState } from 'react';
 
-import type { MarketInfo, MarketReport } from '../../../../api-spec/protobuf/gen/js/tdex-daemon/v1/types_pb';
+import type { MarketReport } from '../../../../api-spec/protobuf/gen/js/tdex-daemon/v1/types_pb';
 import { PredefinedPeriod, TimeFrame } from '../../../../api-spec/protobuf/gen/js/tdex-daemon/v1/types_pb';
 import { useTypedSelector } from '../../../../app/store';
-import { CurrencyIcon } from '../../../../common/CurrencyIcon';
 import { VolumeChart } from '../../../../common/VolumeChart';
 import type { Asset } from '../../../../domain/asset';
-import {
-  formatCompact,
-  fromSatsToUnitOrFractional,
-  isLbtcAssetId,
-  isLbtcTicker,
-  unitToExponent,
-} from '../../../../utils';
-import { convertAmountToFavoriteCurrency, useLatestPriceFeedFromCoinGeckoQuery } from '../../../rates.api';
 
 interface VolumePanelProps {
+  volumeAsFavCurrencyFormatted?: JSX.Element;
   baseAsset: Asset;
-  quoteAsset: Asset;
-  marketInfo?: MarketInfo;
   marketReport?: MarketReport;
   setMarketReportPredefinedPeriod: Dispatch<SetStateAction<PredefinedPeriod>>;
   setMarketReportTimeFrame: Dispatch<SetStateAction<TimeFrame>>;
@@ -30,196 +19,97 @@ interface VolumePanelProps {
 const { Title } = Typography;
 
 export const VolumePanel = ({
+  volumeAsFavCurrencyFormatted,
   baseAsset,
-  quoteAsset,
-  marketInfo,
   marketReport,
   setMarketReportPredefinedPeriod,
   setMarketReportTimeFrame,
   marketReportPredefinedPeriod,
 }: VolumePanelProps): JSX.Element => {
-  const { lbtcUnit, network, currency } = useTypedSelector(({ settings }) => settings);
-  const { data: prices } = useLatestPriceFeedFromCoinGeckoQuery();
-  const [baseAmount, setBaseAmount] = useState<string>();
-  const [quoteAmount, setQuoteAmount] = useState<string>();
-  const [volumeAsFavCurrencyFormatted, setVolumeAsFavCurrencyFormatted] = useState<JSX.Element | undefined>();
-
-  useEffect(() => {
-    setBaseAmount(
-      marketInfo?.balance?.baseAmount === undefined
-        ? 'N/A'
-        : fromSatsToUnitOrFractional(
-            Number(marketInfo?.balance?.baseAmount),
-            baseAsset.precision,
-            isLbtcTicker(baseAsset.ticker),
-            lbtcUnit
-          )
-    );
-    setQuoteAmount(
-      marketInfo?.balance?.quoteAmount === undefined
-        ? 'N/A'
-        : fromSatsToUnitOrFractional(
-            Number(marketInfo?.balance?.quoteAmount),
-            quoteAsset.precision,
-            isLbtcTicker(quoteAsset.ticker),
-            lbtcUnit
-          )
-    );
-
-    const volumeAsUnitOrFractional = fromSatsToUnitOrFractional(
-      Number(marketReport?.totalVolume?.quoteVolume || 0),
-      quoteAsset.precision,
-      isLbtcTicker(quoteAsset.ticker),
-      lbtcUnit
-    );
-
-    const volumeAsFavCurrency = convertAmountToFavoriteCurrency({
-      asset: quoteAsset,
-      amount: volumeAsUnitOrFractional,
-      network: network,
-      preferredCurrency: currency,
-      preferredLbtcUnit: lbtcUnit,
-      prices: prices,
-    });
-
-    setVolumeAsFavCurrencyFormatted(
-      currency.value === 'btc' ? (
-        <div className="d-inline">
-          <span>{Number(volumeAsFavCurrency).toLocaleString('en-US')}</span>
-          <span className="d-inline-block dm-mono dm-mono__x dm_mono__bold mx-2">{lbtcUnit}</span>
-        </div>
-      ) : (
-        <div className="d-inline">
-          <span className="d-inline-block dm-mono dm_mono__bold">{currency.symbol}</span>
-          <span>{Number(volumeAsFavCurrency).toLocaleString('en-US')}</span>
-        </div>
-      )
-    );
-  }, [
-    baseAsset.precision,
-    baseAsset.ticker,
-    currency,
-    lbtcUnit,
-    marketInfo?.balance?.baseAmount,
-    marketInfo?.balance?.quoteAmount,
-    marketReport?.totalVolume?.quoteVolume,
-    network,
-    prices,
-    quoteAsset,
-  ]);
-
+  const { lbtcUnit } = useTypedSelector(({ settings }) => settings);
   return (
-    <div className="panel panel__grey h-100">
-      <Row className="mb-2">
-        <Col span={marketInfo?.strategyType === 0 ? 16 : 24} className="d-flex align-center">
-          <div className="d-flex align-center">
-            <CurrencyIcon assetId={baseAsset?.asset_id} />
-            <span className="dm-mono dm-mono__x dm_mono__bold mx-2">
-              {isLbtcAssetId(baseAsset?.asset_id, network) ? lbtcUnit : baseAsset?.ticker}
-            </span>
-            <span className="dm-mono dm-mono__xx mr-6">{baseAmount}</span>
-          </div>
-          <div className="d-flex align-center">
-            <CurrencyIcon assetId={quoteAsset?.asset_id} />
-            <span className="dm-mono dm-mono__x dm_mono__bold mx-2">
-              {isLbtcAssetId(quoteAsset?.asset_id, network) ? lbtcUnit : quoteAsset?.ticker}
-            </span>
-            <span className="dm-mono dm-mono__xx">{quoteAmount}</span>
-          </div>
-        </Col>
-        {marketInfo?.strategyType === 0 ? (
-          <Col span={8} className="text-end">
-            <span className="dm-mono dm-mono__x dm_mono__bold mx-2">{`${formatCompact(
-              (marketInfo.price?.quotePrice ?? 0) * Math.pow(10, -unitToExponent(lbtcUnit))
-            )} ${isLbtcAssetId(quoteAsset?.asset_id, network) ? lbtcUnit : quoteAsset?.ticker} for 1 ${
-              isLbtcAssetId(baseAsset?.asset_id, network) ? lbtcUnit : baseAsset?.ticker
-            }`}</span>
-          </Col>
-        ) : null}
-      </Row>
-      <VolumeChart
-        topLeft={
-          <div>
-            <Title className="dm-sans dm-sans__x dm-sans__bold dm-sans__grey d-inline" level={3}>
-              Volume
-            </Title>
-            <span className="dm-sans dm-sans__xx ml-2 break-all">{volumeAsFavCurrencyFormatted}</span>
-          </div>
-        }
-        topRight={
-          <div className="text-end">
-            <Radio.Group className="radio-green" defaultValue={marketReportPredefinedPeriod}>
-              <Radio.Button
-                value={PredefinedPeriod.PREDEFINED_PERIOD_LAST_DAY}
-                onClick={() => {
-                  setMarketReportPredefinedPeriod(PredefinedPeriod.PREDEFINED_PERIOD_LAST_DAY);
-                  setMarketReportTimeFrame(TimeFrame.TIME_FRAME_HOUR);
-                }}
-              >
-                1D
-              </Radio.Button>
-              <Radio.Button
-                value={PredefinedPeriod.PREDEFINED_PERIOD_LAST_WEEK}
-                onClick={() => {
-                  setMarketReportPredefinedPeriod(PredefinedPeriod.PREDEFINED_PERIOD_LAST_WEEK);
-                  setMarketReportTimeFrame(TimeFrame.TIME_FRAME_FOUR_HOURS);
-                }}
-              >
-                7D
-              </Radio.Button>
-              <Radio.Button
-                value={PredefinedPeriod.PREDEFINED_PERIOD_LAST_MONTH}
-                onClick={() => {
-                  setMarketReportPredefinedPeriod(PredefinedPeriod.PREDEFINED_PERIOD_LAST_MONTH);
-                  setMarketReportTimeFrame(TimeFrame.TIME_FRAME_DAY);
-                }}
-              >
-                1M
-              </Radio.Button>
-              <Radio.Button
-                value={PredefinedPeriod.PREDEFINED_PERIOD_LAST_THREE_MONTHS}
-                onClick={() => {
-                  setMarketReportPredefinedPeriod(PredefinedPeriod.PREDEFINED_PERIOD_LAST_THREE_MONTHS);
-                  setMarketReportTimeFrame(TimeFrame.TIME_FRAME_DAY);
-                }}
-              >
-                3M
-              </Radio.Button>
-              <Radio.Button
-                value={PredefinedPeriod.PREDEFINED_PERIOD_LAST_YEAR}
-                onClick={() => {
-                  setMarketReportPredefinedPeriod(PredefinedPeriod.PREDEFINED_PERIOD_LAST_YEAR);
-                  setMarketReportTimeFrame(TimeFrame.TIME_FRAME_WEEK);
-                }}
-              >
-                1Y
-              </Radio.Button>
-              <Radio.Button
-                value={PredefinedPeriod.PREDEFINED_PERIOD_YEAR_TO_DATE}
-                onClick={() => {
-                  setMarketReportPredefinedPeriod(PredefinedPeriod.PREDEFINED_PERIOD_YEAR_TO_DATE);
-                  setMarketReportTimeFrame(TimeFrame.TIME_FRAME_WEEK);
-                }}
-              >
-                YTD
-              </Radio.Button>
-              <Radio.Button
-                value={PredefinedPeriod.PREDEFINED_PERIOD_ALL}
-                onClick={() => {
-                  setMarketReportPredefinedPeriod(PredefinedPeriod.PREDEFINED_PERIOD_ALL);
-                  setMarketReportTimeFrame(TimeFrame.TIME_FRAME_WEEK);
-                }}
-              >
-                ALL
-              </Radio.Button>
-            </Radio.Group>
-          </div>
-        }
-        marketReport={marketReport}
-        marketReportPredefinedPeriod={marketReportPredefinedPeriod}
-        baseAsset={baseAsset}
-        lbtcUnit={lbtcUnit}
-      />
-    </div>
+    <VolumeChart
+      topLeft={
+        <div>
+          <Title className="dm-sans dm-sans__x dm-sans__bold dm-sans__grey d-inline" level={3}>
+            Volume
+          </Title>
+          <span className="dm-sans dm-sans__xx ml-2 break-all">{volumeAsFavCurrencyFormatted}</span>
+        </div>
+      }
+      topRight={
+        <div className="text-end">
+          <Radio.Group className="radio-green" defaultValue={marketReportPredefinedPeriod}>
+            <Radio.Button
+              value={PredefinedPeriod.PREDEFINED_PERIOD_LAST_DAY}
+              onClick={() => {
+                setMarketReportPredefinedPeriod(PredefinedPeriod.PREDEFINED_PERIOD_LAST_DAY);
+                setMarketReportTimeFrame(TimeFrame.TIME_FRAME_HOUR);
+              }}
+            >
+              1D
+            </Radio.Button>
+            <Radio.Button
+              value={PredefinedPeriod.PREDEFINED_PERIOD_LAST_WEEK}
+              onClick={() => {
+                setMarketReportPredefinedPeriod(PredefinedPeriod.PREDEFINED_PERIOD_LAST_WEEK);
+                setMarketReportTimeFrame(TimeFrame.TIME_FRAME_FOUR_HOURS);
+              }}
+            >
+              7D
+            </Radio.Button>
+            <Radio.Button
+              value={PredefinedPeriod.PREDEFINED_PERIOD_LAST_MONTH}
+              onClick={() => {
+                setMarketReportPredefinedPeriod(PredefinedPeriod.PREDEFINED_PERIOD_LAST_MONTH);
+                setMarketReportTimeFrame(TimeFrame.TIME_FRAME_DAY);
+              }}
+            >
+              1M
+            </Radio.Button>
+            <Radio.Button
+              value={PredefinedPeriod.PREDEFINED_PERIOD_LAST_THREE_MONTHS}
+              onClick={() => {
+                setMarketReportPredefinedPeriod(PredefinedPeriod.PREDEFINED_PERIOD_LAST_THREE_MONTHS);
+                setMarketReportTimeFrame(TimeFrame.TIME_FRAME_DAY);
+              }}
+            >
+              3M
+            </Radio.Button>
+            <Radio.Button
+              value={PredefinedPeriod.PREDEFINED_PERIOD_LAST_YEAR}
+              onClick={() => {
+                setMarketReportPredefinedPeriod(PredefinedPeriod.PREDEFINED_PERIOD_LAST_YEAR);
+                setMarketReportTimeFrame(TimeFrame.TIME_FRAME_WEEK);
+              }}
+            >
+              1Y
+            </Radio.Button>
+            <Radio.Button
+              value={PredefinedPeriod.PREDEFINED_PERIOD_YEAR_TO_DATE}
+              onClick={() => {
+                setMarketReportPredefinedPeriod(PredefinedPeriod.PREDEFINED_PERIOD_YEAR_TO_DATE);
+                setMarketReportTimeFrame(TimeFrame.TIME_FRAME_WEEK);
+              }}
+            >
+              YTD
+            </Radio.Button>
+            <Radio.Button
+              value={PredefinedPeriod.PREDEFINED_PERIOD_ALL}
+              onClick={() => {
+                setMarketReportPredefinedPeriod(PredefinedPeriod.PREDEFINED_PERIOD_ALL);
+                setMarketReportTimeFrame(TimeFrame.TIME_FRAME_WEEK);
+              }}
+            >
+              ALL
+            </Radio.Button>
+          </Radio.Group>
+        </div>
+      }
+      marketReport={marketReport}
+      marketReportPredefinedPeriod={marketReportPredefinedPeriod}
+      baseAsset={baseAsset}
+      lbtcUnit={lbtcUnit}
+    />
   );
 };

--- a/src/features/operator/Market/MarketOverview/index.tsx
+++ b/src/features/operator/Market/MarketOverview/index.tsx
@@ -20,6 +20,7 @@ import { MarketSettings } from '../MarketSettings';
 
 import { AssetInfoModal } from './AssetInfoModal';
 import { BalanceAndPrice } from './BalanceAndPrice';
+import { BalanceAndPriceMobile } from './BalanceAndPriceMobile';
 import { CollectedSwapFees } from './CollectedSwapFees';
 import { VolumePanel } from './VolumePanel';
 
@@ -253,7 +254,7 @@ export const MarketOverview = (): JSX.Element => {
             )}
           </Col>
           <Col
-            xs={24}
+            xs={0}
             sm={24}
             md={24}
             lg={16}
@@ -285,6 +286,20 @@ export const MarketOverview = (): JSX.Element => {
               </>
             </div>
           </Col>
+          {/* To remove if multi panel layout is adopted on bigger screens */}
+          <>
+            {screens.xs ? (
+              <BalanceAndPriceMobile
+                baseAsset={state?.baseAsset}
+                quoteAsset={state?.quoteAsset}
+                lbtcUnit={lbtcUnit}
+                baseAmount={baseAmount}
+                quoteAmount={quoteAmount}
+                marketInfo={marketInfo}
+                network={network}
+              />
+            ) : null}
+          </>
         </Row>
         <div>
           <Title className="dm-sans dm-sans__x dm-sans__bold dm-sans__grey" level={2}>

--- a/src/features/operator/Market/MarketOverview/index.tsx
+++ b/src/features/operator/Market/MarketOverview/index.tsx
@@ -12,12 +12,15 @@ import { MarketIcons } from '../../../../common/MarketIcons';
 import type { Asset } from '../../../../domain/asset';
 import { HOME_ROUTE, MARKET_DEPOSIT_ROUTE, MARKET_WITHDRAW_ROUTE } from '../../../../routes/constants';
 import { fromSatsToUnitOrFractional, isLbtcTicker } from '../../../../utils';
+import { convertAmountToFavoriteCurrency, useLatestPriceFeedFromCoinGeckoQuery } from '../../../rates.api';
 import { FeeForm } from '../../Fee/FeeForm';
 import { TxsTable } from '../../TxsTable';
 import { useGetMarketBalanceQuery, useGetMarketInfoQuery, useGetMarketReportQuery } from '../../operator.api';
 import { MarketSettings } from '../MarketSettings';
 
 import { AssetInfoModal } from './AssetInfoModal';
+import { BalanceAndPrice } from './BalanceAndPrice';
+import { CollectedSwapFees } from './CollectedSwapFees';
 import { VolumePanel } from './VolumePanel';
 
 const { Title } = Typography;
@@ -26,7 +29,6 @@ const { useBreakpoint } = Grid;
 export const MarketOverview = (): JSX.Element => {
   const navigate = useNavigate();
   const marketsLabelled = useTypedSelector(({ settings }) => settings.marketsLabelled);
-  const lbtcUnit = useTypedSelector(({ settings }) => settings.lbtcUnit);
   const { state } = useLocation() as { state: { baseAsset: Asset; quoteAsset: Asset } };
   const [isBalanceUpdating, setIsBalanceUpdating] = useState<boolean>(false);
   const { data: marketBalance } = useGetMarketBalanceQuery(
@@ -47,6 +49,11 @@ export const MarketOverview = (): JSX.Element => {
       pollingInterval: isBalanceUpdating ? 2000 : 0,
     }
   );
+  const [baseAmount, setBaseAmount] = useState<string>();
+  const [quoteAmount, setQuoteAmount] = useState<string>();
+  const [volumeAsFavCurrencyFormatted, setVolumeAsFavCurrencyFormatted] = useState<JSX.Element | undefined>();
+  const { lbtcUnit, network, currency } = useTypedSelector(({ settings }) => settings);
+  const { data: prices } = useLatestPriceFeedFromCoinGeckoQuery();
   const screens = useBreakpoint();
 
   // Market report
@@ -96,6 +103,70 @@ export const MarketOverview = (): JSX.Element => {
   const handleAssetInfoModalCancel = () => {
     setIsAssetInfoModalVisible(false);
   };
+
+  useEffect(() => {
+    setBaseAmount(
+      marketInfo?.balance?.baseAmount === undefined
+        ? 'N/A'
+        : fromSatsToUnitOrFractional(
+            Number(marketInfo?.balance?.baseAmount),
+            state?.baseAsset.precision,
+            isLbtcTicker(state?.baseAsset.ticker),
+            lbtcUnit
+          )
+    );
+    setQuoteAmount(
+      marketInfo?.balance?.quoteAmount === undefined
+        ? 'N/A'
+        : fromSatsToUnitOrFractional(
+            Number(marketInfo?.balance?.quoteAmount),
+            state?.quoteAsset.precision,
+            isLbtcTicker(state?.quoteAsset.ticker),
+            lbtcUnit
+          )
+    );
+
+    const volumeAsUnitOrFractional = fromSatsToUnitOrFractional(
+      Number(marketReport?.totalVolume?.quoteVolume || 0),
+      state?.quoteAsset.precision,
+      isLbtcTicker(state?.quoteAsset.ticker),
+      lbtcUnit
+    );
+
+    const volumeAsFavCurrency = convertAmountToFavoriteCurrency({
+      asset: state?.quoteAsset,
+      amount: volumeAsUnitOrFractional,
+      network: network,
+      preferredCurrency: currency,
+      preferredLbtcUnit: lbtcUnit,
+      prices: prices,
+    });
+
+    setVolumeAsFavCurrencyFormatted(
+      currency.value === 'btc' ? (
+        <div className="d-inline">
+          <span>{Number(volumeAsFavCurrency).toLocaleString('en-US')}</span>
+          <span className="d-inline-block dm-mono dm-mono__x dm_mono__bold mx-2">{lbtcUnit}</span>
+        </div>
+      ) : (
+        <div className="d-inline">
+          <span className="d-inline-block dm-mono dm_mono__bold">{currency.symbol}</span>
+          <span>{Number(volumeAsFavCurrency).toLocaleString('en-US')}</span>
+        </div>
+      )
+    );
+  }, [
+    state?.baseAsset.precision,
+    state?.baseAsset.ticker,
+    currency,
+    lbtcUnit,
+    marketInfo?.balance?.baseAmount,
+    marketInfo?.balance?.quoteAmount,
+    marketReport?.totalVolume?.quoteVolume,
+    network,
+    prices,
+    state?.quoteAsset,
+  ]);
 
   return (
     <>
@@ -159,44 +230,7 @@ export const MarketOverview = (): JSX.Element => {
         </Row>
         <Row className="mb-8" gutter={{ xs: 4, sm: 8, md: 12 }}>
           <Col xs={24} sm={24} md={24} lg={8} className="h-100">
-            <div className="panel panel__grey mb-4">
-              <Row>
-                <Col span={24}>
-                  <Title className="dm-sans dm-sans__x dm-sans__bold dm-sans__grey d-inline mr-4" level={3}>
-                    Collected Swap Fees
-                  </Title>
-                  <InfoCircleOutlined className="grey" />
-                </Col>
-              </Row>
-              <Row align="middle">
-                <Col>
-                  <div>
-                    <span className="dm-mono dm-mono__xx">
-                      {fromSatsToUnitOrFractional(
-                        marketReport?.totalCollectedFees?.baseAmount ?? 0,
-                        state?.baseAsset?.precision,
-                        isLbtcTicker(state?.baseAsset?.ticker),
-                        lbtcUnit
-                      )}
-                    </span>
-                    <span className="dm-sans dm-sans__x ml-2">{state?.baseAsset?.formattedTicker ?? ''}</span>
-                  </div>
-                  <div>
-                    <span className="dm-mono dm-mono__xx">
-                      {fromSatsToUnitOrFractional(
-                        marketReport?.totalCollectedFees?.quoteAmount ?? 0,
-                        state?.quoteAsset?.precision,
-                        isLbtcTicker(state?.quoteAsset?.ticker),
-                        lbtcUnit
-                      )}
-                    </span>
-                    <span className="dm-sans dm-sans__x ml-2">
-                      {state?.quoteAsset?.formattedTicker ?? ''}
-                    </span>
-                  </div>
-                </Col>
-              </Row>
-            </div>
+            <CollectedSwapFees marketReport={marketReport} state={state} />
 
             {/* Render FeeForm only when marketInfo is ready */}
             {/* To ensure AntD form initialValues are correct */}
@@ -219,7 +253,7 @@ export const MarketOverview = (): JSX.Element => {
             )}
           </Col>
           <Col
-            xs={0}
+            xs={24}
             sm={24}
             md={24}
             lg={16}
@@ -227,15 +261,29 @@ export const MarketOverview = (): JSX.Element => {
               'mt-4': !screens.lg,
             })}
           >
-            <VolumePanel
-              marketInfo={marketInfo}
-              baseAsset={state?.baseAsset}
-              quoteAsset={state?.quoteAsset}
-              marketReport={marketReport}
-              setMarketReportPredefinedPeriod={setMarketReportPredefinedPeriod}
-              setMarketReportTimeFrame={setMarketReportTimeFrame}
-              marketReportPredefinedPeriod={marketReportPredefinedPeriod}
-            />
+            <div className="panel panel__grey h-100">
+              <BalanceAndPrice
+                baseAsset={state?.baseAsset}
+                quoteAsset={state?.quoteAsset}
+                lbtcUnit={lbtcUnit}
+                baseAmount={baseAmount}
+                quoteAmount={quoteAmount}
+                marketInfo={marketInfo}
+                network={network}
+              />
+              <>
+                {!screens.xs ? (
+                  <VolumePanel
+                    volumeAsFavCurrencyFormatted={volumeAsFavCurrencyFormatted}
+                    baseAsset={state?.baseAsset}
+                    marketReport={marketReport}
+                    setMarketReportPredefinedPeriod={setMarketReportPredefinedPeriod}
+                    setMarketReportTimeFrame={setMarketReportTimeFrame}
+                    marketReportPredefinedPeriod={marketReportPredefinedPeriod}
+                  />
+                ) : null}
+              </>
+            </div>
           </Col>
         </Row>
         <div>

--- a/src/features/operator/TxsTable/txsTable.less
+++ b/src/features/operator/TxsTable/txsTable.less
@@ -20,6 +20,7 @@ table#txs-table {
         position: sticky;
         left: -1px;
         background: @grey-x-dark;
+        background-clip: padding-box;
       }
     }
     tr {
@@ -42,7 +43,7 @@ table#txs-table {
       }
     }
     tr:not(.details) {
-      border-top: 1px solid #CCCCCC;
+      border-top: 0.5px solid #CCCCCC;
       height: 50px;
       .anticon.anticon-right {
         rotate: 0deg;


### PR DESCRIPTION
Display Market balance and price when strategy pluggable on mobile

<img width="462" alt="Screenshot 2022-12-23 at 11 49 22" src="https://user-images.githubusercontent.com/4022128/209323265-d7a611a4-265f-41b4-8a87-8ad57b753b89.png">

@tiero Should we add a title and tooltip? If so, I would refactor also not mobile design, having market balance and price on its own panel. 
