### PR TITLE
Add providerShortName to fix notarization

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -60,7 +60,8 @@
         "exceptionDomain": "",
         "frameworks": [],
         "minimumSystemVersion": "11.0",
-        "signingIdentity": null
+        "signingIdentity": null,
+        "providerShortName": "5G3423SYA4"
       },
       "resources": [],
       "shortDescription": "",


### PR DESCRIPTION
Should fix CI error `Unable to upload your app for notarization. --notarize-app is missing one or more required options: --asc-provider.`