### PR TITLE
Fix TdexdConnectUrl in packaged mode

### DIFF
--- a/src/features/walletUnlocker/OnboardingConfirmMnemonic.tsx
+++ b/src/features/walletUnlocker/OnboardingConfirmMnemonic.tsx
@@ -16,8 +16,13 @@ import {
   ONBOARDING_PAIRING_ROUTE,
   ONBOARDING_SHOW_MNEMONIC_ROUTE,
 } from '../../routes/constants';
-import { sleep, encodeBase64UrlMacaroon } from '../../utils';
-import { setMacaroonCredentials, setTdexdConnectUrl } from '../settings/settingsSlice';
+import {
+  sleep,
+  encodeBase64UrlMacaroon,
+  extractConnectUrlData,
+  checkConnectUrlDataValidity,
+} from '../../utils';
+import { getTdexdConnectUrl, setMacaroonCredentials, setTdexdConnectUrl } from '../settings/settingsSlice';
 
 import { useInitWalletMutation, useUnlockWalletMutation } from './walletUnlocker.api';
 
@@ -59,14 +64,23 @@ export const OnboardingConfirmMnemonic = (): JSX.Element => {
         if (message.data.length > 150) {
           dispatch(setMacaroonCredentials(message.data));
           const base64UrlMacaroon = encodeBase64UrlMacaroon(message.data);
-          dispatch(setTdexdConnectUrl(tdexdConnectUrl + '&macaroon=' + base64UrlMacaroon));
+          if ((window as any).IS_PACKAGED) {
+            const connectUrl = await dispatch(getTdexdConnectUrl(state.password)).unwrap();
+            const connectUrlData = extractConnectUrlData(connectUrl);
+            if (connectUrlData && checkConnectUrlDataValidity(connectUrlData)) {
+              dispatch(setTdexdConnectUrl(connectUrl + '&macaroon=' + base64UrlMacaroon));
+            }
+          } else {
+            dispatch(setTdexdConnectUrl(tdexdConnectUrl + '&macaroon=' + base64UrlMacaroon));
+          }
         }
       }
       const status = await data.status;
       if (status.code === 'OK') {
         await sleep(1000);
         await unlockWallet({ walletPassword: Buffer.from(state.password) });
-        await sleep(1000);
+        // Wait for daemon to unlock before navigating to home and calling other endpoints
+        await sleep(2000);
         setIsLoading(false);
         navigate(HOME_ROUTE);
       } else {

--- a/src/features/walletUnlocker/OnboardingPairing.tsx
+++ b/src/features/walletUnlocker/OnboardingPairing.tsx
@@ -18,6 +18,7 @@ import { liquidApi } from '../liquid.api';
 import { operatorApi } from '../operator/operator.api';
 import {
   getTdexdConnectUrl,
+  logout,
   setBaseUrl,
   setConnectUrlProto,
   setMacaroonCredentials,
@@ -62,6 +63,7 @@ export const OnboardingPairing = (): JSX.Element => {
       dispatch(operatorApi.util.resetApiState());
       dispatch(walletUnlockerApi.util.resetApiState());
       dispatch(walletApi.util.resetApiState());
+      dispatch(logout());
       // Auto connect if IS_PACKAGED (like in Umbrel)
       if ((window as any).IS_PACKAGED) {
         // isPackaged is false on first load, set it to true


### PR DESCRIPTION
- TdexdConnectUrl needs to be fetched at wallet creation/restore when in packaged mode
- Wait a bit more after daemon wallet unlock to avoid "getInfo not ready" error
- Close restoration modal only at the very end